### PR TITLE
fix(events): correct "3 derniers événements", default period and JSON-LD

### DIFF
--- a/app/(client)/events/_components/event-detail.tsx
+++ b/app/(client)/events/_components/event-detail.tsx
@@ -9,7 +9,6 @@ import { urlFor } from '@/sanity/lib/imageUrl';
 import { ArrowRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import Script from 'next/script';
 import { EventOriginBadge } from './event-origin-badge';
 
 interface EventDetailProps {
@@ -53,8 +52,8 @@ export default function EventDetail({ event }: EventDetailProps) {
 
     return (
         <>
-            <Script
-                id='event-jsonld'
+            {/* Balise native (pas next/script) pour que le JSON-LD soit dans le HTML servi aux crawlers */}
+            <script
                 type='application/ld+json'
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
             />

--- a/app/(client)/events/_components/event-filter.tsx
+++ b/app/(client)/events/_components/event-filter.tsx
@@ -10,67 +10,73 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import {
+    EventOriginFilter,
+    EventPeriod,
+    selectEventsByPeriod,
+} from '@/lib/selectEventsByPeriod';
 import { Evenement } from '@/sanity.types';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import NextEventCard from './next-event-card';
 
 interface ClientEventFilterProps {
     events: Evenement[];
+    /**
+     * Période sélectionnée au chargement. Le serveur la calcule : "past" s'il
+     * n'y a aucun événement à venir en dehors de celui mis en avant.
+     */
+    defaultPeriod?: EventPeriod;
 }
 
-const ClientEventFilter: React.FC<ClientEventFilterProps> = ({ events }) => {
-    const [selectedOption, setSelectedOption] = useState('next');
-    const [originFilter, setOriginFilter] = useState<
-        'all' | 'internal' | 'external'
-    >('all');
-    const [filteredEvents, setFilteredEvents] = useState<Evenement[]>([]);
+const SECTION_TITLE: Record<EventPeriod, string> = {
+    next: 'Nos autres événements à venir',
+    past: 'Nos derniers événements',
+};
+
+const EMPTY_MESSAGE: Record<EventPeriod, string> = {
+    next: "Nous n'avons pas encore publié d'événements à venir.",
+    past: "Aucun événement passé ne correspond à ce filtre.",
+};
+
+const ClientEventFilter: React.FC<ClientEventFilterProps> = ({
+    events,
+    defaultPeriod = 'next',
+}) => {
+    const [period, setPeriod] = useState<EventPeriod>(defaultPeriod);
+    const [originFilter, setOriginFilter] = useState<EventOriginFilter>('all');
     const [isLoading, setIsLoading] = useState(false);
+    const isFirstRender = useRef(true);
 
+    // Liste dérivée de l'état, donc disponible dès le rendu serveur
+    const filteredEvents = useMemo(
+        () => selectEventsByPeriod(events, { period, origin: originFilter }),
+        [events, period, originFilter]
+    );
+
+    // Skeleton uniquement lors d'un changement de filtre, pas au chargement initial
     useEffect(() => {
-        setIsLoading(true);
-        const today = new Date();
-        const byOrigin = (evts: Evenement[]) =>
-            originFilter === 'all'
-                ? evts
-                : evts.filter((e: any) => e.origin === originFilter);
-
-        if (selectedOption === 'next') {
-            const nextEvents = byOrigin(
-                events.filter(
-                    (event) => new Date(event.eventDates?.[0] || '') >= today
-                )
-            ).slice(0, 3);
-            setFilteredEvents(nextEvents);
-        } else {
-            const pastEvents = byOrigin(
-                events.filter(
-                    (event) => new Date(event.eventDates?.[0] || '') < today
-                )
-            ).slice(0, 3);
-            setFilteredEvents(pastEvents);
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
         }
-        // Simuler un délai de chargement
-        setTimeout(() => setIsLoading(false), 100);
-    }, [selectedOption, originFilter, events]);
-
-    const handleSelectChange = (value: string) => {
-        setSelectedOption(value);
-    };
-    const handleOriginChange = (value: 'all' | 'internal' | 'external') => {
-        setOriginFilter(value);
-    };
+        setIsLoading(true);
+        const timer = setTimeout(() => setIsLoading(false), 100);
+        return () => clearTimeout(timer);
+    }, [period, originFilter]);
 
     return (
         <FadeInWrapper delay={0.2}>
             <div className='flex flex-col gap-4 items-center justify-center mt-16 max-md:py-8 w-full'>
                 <h2 className='text-2xl font-bold text-white text-center px-10'>
-                    Nos autres événements à venir
+                    {SECTION_TITLE[period]}
                 </h2>
                 <div className='flex justify-center px-6 w-full gap-3'>
                     <Select
-                        value={selectedOption}
-                        onValueChange={handleSelectChange}
+                        value={period}
+                        onValueChange={(value) =>
+                            setPeriod(value as EventPeriod)
+                        }
                     >
                         <SelectTrigger className='w-full md:w-fit space-x-2'>
                             <SelectValue placeholder='Sélectionner les événements' />
@@ -90,7 +96,9 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({ events }) => {
 
                     <Select
                         value={originFilter}
-                        onValueChange={(v) => handleOriginChange(v as any)}
+                        onValueChange={(value) =>
+                            setOriginFilter(value as EventOriginFilter)
+                        }
                     >
                         <SelectTrigger className='w-full md:w-fit space-x-2'>
                             <SelectValue placeholder="Origine de l'événement" />
@@ -110,7 +118,11 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({ events }) => {
                     </Select>
                 </div>
             </div>
-            <NextEventCard events={filteredEvents} isLoading={isLoading} />
+            <NextEventCard
+                events={filteredEvents}
+                isLoading={isLoading}
+                emptyMessage={EMPTY_MESSAGE[period]}
+            />
         </FadeInWrapper>
     );
 };

--- a/app/(client)/events/_components/next-event-card.tsx
+++ b/app/(client)/events/_components/next-event-card.tsx
@@ -7,9 +7,15 @@ import CardEvent from './card-event';
 interface NextEventCardProps {
     events: Evenement[];
     isLoading: boolean;
+    /** Message affiché quand aucun événement ne correspond au filtre. */
+    emptyMessage?: string;
 }
 
-function NextEventCard({ events, isLoading }: NextEventCardProps) {
+function NextEventCard({
+    events,
+    isLoading,
+    emptyMessage = "Nous n'avons pas encore publié d'événements à venir.",
+}: NextEventCardProps) {
     if (isLoading) {
         return (
             <section className='container flex max-md:flex-col max-md:space-y-20 md:p-20 md:justify-between'>
@@ -74,8 +80,7 @@ function NextEventCard({ events, isLoading }: NextEventCardProps) {
                 <div className='flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm py-4'>
                     <div className='flex flex-col items-center gap-1 text-center'>
                         <h3 className='text-base md:text-2xl font-bold tracking-tight'>
-                            Nous n&apos;avons pas encore publié
-                            d&apos;événements à venir.
+                            {emptyMessage}
                         </h3>
                     </div>
                 </div>

--- a/app/(client)/events/page.tsx
+++ b/app/(client)/events/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import GradualSpacing from '@/components/ui/gradual-spacing';
 import { formatEventDates } from '@/lib/formatEventDate';
 import { getCurrentSeason } from '@/lib/getCurrentSeason';
+import { hasUpcomingEvents } from '@/lib/selectEventsByPeriod';
 import { sortEventsByDate } from '@/lib/sortEventsByDate';
 import { Evenement, EVENTS_QUERYResult } from '@/sanity.types';
 import { sanityFetch } from '@/sanity/lib/fetch';
@@ -118,6 +119,12 @@ export default async function Events() {
         (event) => event !== firstEventOrLatest
     );
 
+    // Sans autre événement à venir, le filtre s'ouvre sur les derniers événements
+    // plutôt que sur une liste "à venir" vide.
+    const defaultPeriod = hasUpcomingEvents(remainingEvents, today)
+        ? 'next'
+        : 'past';
+
     const formattedEventDates = formatEventDates(firstEventOrLatest.eventDates);
 
     return (
@@ -223,7 +230,10 @@ export default async function Events() {
             {/* Section des événements restants */}
             <section id='event-filter-section' className='scroll-smooth'>
                 <div className='container mx-auto p-4'>
-                    <ClientEventFilter events={remainingEvents} />
+                    <ClientEventFilter
+                        events={remainingEvents}
+                        defaultPeriod={defaultPeriod}
+                    />
                 </div>
             </section>
         </section>

--- a/app/(client)/layout.tsx
+++ b/app/(client)/layout.tsx
@@ -13,7 +13,6 @@ import {
     Inter as FontSans,
     Merriweather as FontSerif,
 } from 'next/font/google';
-import Script from 'next/script';
 import { Suspense } from 'react';
 import '../globals.css';
 
@@ -138,20 +137,17 @@ export default function RootLayout({
                     cinzelDecorative.variable
                 )}
             >
-                {/* Organization JSON-LD global */}
-                <Script
-                    id='org-jsonld'
+                {/* JSON-LD en balises natives : next/script les injecterait côté client,
+                    hors du HTML initial lu par les crawlers */}
+                <script
                     type='application/ld+json'
-                    strategy='afterInteractive'
                     dangerouslySetInnerHTML={{
                         __html: JSON.stringify(orgJsonLd),
                     }}
                 />
                 {/* WebSite JSON-LD global (sans SearchAction car pas de recherche interne) */}
-                <Script
-                    id='website-jsonld'
+                <script
                     type='application/ld+json'
-                    strategy='afterInteractive'
                     dangerouslySetInnerHTML={{
                         __html: JSON.stringify(websiteJsonLd),
                     }}

--- a/lib/selectEventsByPeriod.test.ts
+++ b/lib/selectEventsByPeriod.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    hasUpcomingEvents,
+    selectEventsByPeriod,
+} from './selectEventsByPeriod.ts';
+
+type TestEvent = {
+    _id: string;
+    eventDates?: string[];
+    origin?: 'internal' | 'external';
+};
+
+const today = new Date('2026-08-23T00:00:00Z');
+
+const event = (
+    id: string,
+    date: string,
+    origin: 'internal' | 'external' = 'internal'
+): TestEvent => ({ _id: id, eventDates: [date], origin });
+
+// Volontairement dans le désordre pour vérifier que le tri ne dépend pas de l'entrée
+const events: TestEvent[] = [
+    event('past-2023', '2023-06-17'),
+    event('future-2027', '2027-01-10', 'external'),
+    event('past-2025-apr', '2025-04-05'),
+    event('past-2026-mar', '2026-03-21'),
+    event('future-2026-oct', '2026-10-03'),
+    event('past-2024', '2024-11-09', 'external'),
+    event('past-2025-dec', '2025-12-06'),
+    event('future-2026-sep', '2026-09-12'),
+];
+
+describe('selectEventsByPeriod', () => {
+    it('returns the 3 most recent past events, newest first', () => {
+        const result = selectEventsByPeriod(events, {
+            period: 'past',
+            origin: 'all',
+            today,
+        });
+        assert.deepEqual(
+            result.map((e) => e._id),
+            ['past-2026-mar', 'past-2025-dec', 'past-2025-apr']
+        );
+    });
+
+    it('returns the 3 next upcoming events, soonest first', () => {
+        const result = selectEventsByPeriod(events, {
+            period: 'next',
+            origin: 'all',
+            today,
+        });
+        assert.deepEqual(
+            result.map((e) => e._id),
+            ['future-2026-sep', 'future-2026-oct', 'future-2027']
+        );
+    });
+
+    it('applies the origin filter before taking the first 3', () => {
+        const result = selectEventsByPeriod(events, {
+            period: 'past',
+            origin: 'external',
+            today,
+        });
+        assert.deepEqual(
+            result.map((e) => e._id),
+            ['past-2024']
+        );
+    });
+
+    it('ignores events without a valid date', () => {
+        const result = selectEventsByPeriod(
+            [{ _id: 'no-date' }, { _id: 'bad-date', eventDates: ['nope'] }],
+            { period: 'past', origin: 'all', today }
+        );
+        assert.deepEqual(result, []);
+    });
+
+    it('counts an event starting today as upcoming', () => {
+        const result = selectEventsByPeriod(
+            [event('today', '2026-08-23')],
+            { period: 'next', origin: 'all', today }
+        );
+        assert.deepEqual(
+            result.map((e) => e._id),
+            ['today']
+        );
+    });
+});
+
+describe('hasUpcomingEvents', () => {
+    it('is true when at least one event starts today or later', () => {
+        assert.equal(hasUpcomingEvents(events, today), true);
+    });
+
+    it('is false when every event is in the past', () => {
+        const pastOnly = events.filter((e) => e._id.startsWith('past'));
+        assert.equal(hasUpcomingEvents(pastOnly, today), false);
+    });
+
+    it('is false for an empty list', () => {
+        assert.equal(hasUpcomingEvents([], today), false);
+    });
+});

--- a/lib/selectEventsByPeriod.ts
+++ b/lib/selectEventsByPeriod.ts
@@ -1,0 +1,84 @@
+/**
+ * Sélection des événements affichés sous l'événement mis en avant.
+ *
+ * Logique métier pure, sans dépendance React ni Sanity, pour rester testable.
+ * Le composant client ne fait que relier l'état des <Select> à cette fonction.
+ */
+
+export type EventPeriod = 'next' | 'past';
+export type EventOriginFilter = 'all' | 'internal' | 'external';
+
+/** Sous-ensemble minimal d'un `Evenement` Sanity nécessaire à la sélection. */
+export type SelectableEvent = {
+    eventDates?: string[];
+    origin?: 'internal' | 'external';
+};
+
+export type SelectEventsOptions = {
+    period: EventPeriod;
+    origin: EventOriginFilter;
+    /** Injectable pour les tests. Par défaut : maintenant. */
+    today?: Date;
+    /** Nombre maximum d'événements retournés. Par défaut : 3. */
+    limit?: number;
+};
+
+const DEFAULT_LIMIT = 3;
+
+/** Timestamp de la première date de l'événement, ou `null` si absente/invalide. */
+const startTimestamp = (event: SelectableEvent): number | null => {
+    const raw = event.eventDates?.[0];
+    if (!raw) return null;
+    const time = new Date(raw).getTime();
+    return Number.isNaN(time) ? null : time;
+};
+
+const isUpcoming = (event: SelectableEvent, today: Date): boolean => {
+    const time = startTimestamp(event);
+    return time !== null && time >= today.getTime();
+};
+
+/**
+ * Retourne les `limit` événements de la période demandée.
+ *
+ * - `next` : événements à venir, du plus proche au plus lointain.
+ * - `past` : événements passés, du plus récent au plus ancien.
+ *
+ * Le filtre d'origine s'applique avant la troncature, pour que "3 derniers
+ * événements externes" renvoie bien 3 événements externes si disponibles.
+ */
+export const selectEventsByPeriod = <T extends SelectableEvent>(
+    events: T[],
+    { period, origin, today = new Date(), limit = DEFAULT_LIMIT }: SelectEventsOptions
+): T[] => {
+    const now = today.getTime();
+
+    const inPeriod = (event: T): boolean => {
+        const time = startTimestamp(event);
+        if (time === null) return false;
+        return period === 'next' ? time >= now : time < now;
+    };
+
+    const inOrigin = (event: T): boolean =>
+        origin === 'all' || event.origin === origin;
+
+    // Croissant pour "à venir" (le plus proche d'abord),
+    // décroissant pour "passés" (le plus récent d'abord).
+    const direction = period === 'next' ? 1 : -1;
+
+    return events
+        .filter((event) => inPeriod(event) && inOrigin(event))
+        .sort(
+            (a, b) =>
+                ((startTimestamp(a) as number) -
+                    (startTimestamp(b) as number)) *
+                direction
+        )
+        .slice(0, limit);
+};
+
+/** Vrai s'il existe au moins un événement qui commence aujourd'hui ou plus tard. */
+export const hasUpcomingEvents = (
+    events: SelectableEvent[],
+    today: Date = new Date()
+): boolean => events.some((event) => isUpcoming(event, today));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "dev": "next dev --turbopack",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "test": "node --test \"lib/**/*.test.ts\""
     },
     "dependencies": {
         "@lordicon/element": "^1.6.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Correctifs

### "3 derniers événements" remontait les événements de 2023
La liste était triée par date croissante et le filtre "derniers" prenait les 3 premiers, donc les 3 plus anciens. La sélection vit maintenant dans `lib/selectEventsByPeriod.ts` (fonction pure, 8 tests via `pnpm test` sur le runner natif Node) : à venir triés du plus proche au plus lointain, passés du plus récent au plus ancien, filtre d'origine appliqué avant la limite de 3.

### Période par défaut
Calculée côté serveur : "3 derniers événements" s'il n'y a aucun événement à venir en dehors de celui mis en avant, sinon "3 prochains". Titre de section et message d'état vide suivent la période.

### Cartes rendues côté serveur
Liste dérivée avec `useMemo` au lieu d'un `useEffect` partant d'un tableau vide : les cartes sont dans le HTML initial, le skeleton n'apparaît qu'au changement de filtre.

### JSON-LD dans le HTML initial
`next/script` injectait les données structurées côté client, hors du HTML lu par les crawlers. Balises `<script type="application/ld+json">` natives pour `Event` (page détail), `Organization` et `WebSite` (layout).

## Vérification
- `tsc --noEmit` OK, `pnpm build` OK, `pnpm test` 8/8
- Build prod local : `/events` s'ouvre sur "Nos derniers événements" avec les cartes du 26/06, 09/05 et 18/04/2026, JSON-LD présent dans le HTML de `/` et `/events/[id]`
- Changement de filtre testé en navigateur, aucune erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)