### PR TITLE
chore: regenerate Sanity types and migrate to ESLint 9 flat config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/app/(client)/events/[eventId]/page.tsx
+++ b/app/(client)/events/[eventId]/page.tsx
@@ -33,8 +33,8 @@ export async function generateMetadata(
     const imageUrl = event.mainImage?.asset?._ref
         ? urlFor(event.mainImage.asset._ref).width(1200).height(630).url()
         : '';
-    const isExternal = (event as any)?.origin === 'external';
-    const externalUrl: string | undefined = (event as any)?.externalUrl;
+    const isExternal = event.origin === 'external';
+    const externalUrl = event.externalUrl;
 
     return {
         title: event.title,

--- a/app/(client)/events/_components/event-detail.tsx
+++ b/app/(client)/events/_components/event-detail.tsx
@@ -23,12 +23,8 @@ export default function EventDetail({ event }: EventDetailProps) {
         ? urlFor(event.personality.photo.asset._ref).url()
         : '';
     const formattedEventDates = formatEventDates(event.eventDates);
-    const isExternal = (event as any)?.origin === 'external';
-    const origin = (event as any)?.origin as
-        | 'internal'
-        | 'external'
-        | undefined;
-    const externalUrl: string | undefined = (event as any)?.externalUrl;
+    const isExternal = event.origin === 'external';
+    const externalUrl = event.externalUrl;
 
     const jsonLd = {
         '@context': 'https://schema.org',
@@ -77,7 +73,7 @@ export default function EventDetail({ event }: EventDetailProps) {
                         {event.title || 'Événement sans titre'}
                     </h1>
                     <div className='flex items-center justify-center mb-4'>
-                        <EventOriginBadge origin={origin} />
+                        <EventOriginBadge origin={event.origin} />
                     </div>
                     <div className='flex justify-center mb-6'>
                         <strong className='text-lg md:text-2xl text-gray-600'>

--- a/app/(client)/events/_components/event-filter.tsx
+++ b/app/(client)/events/_components/event-filter.tsx
@@ -46,7 +46,9 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({
     const [period, setPeriod] = useState<EventPeriod>(defaultPeriod);
     const [originFilter, setOriginFilter] = useState<EventOriginFilter>('all');
     const [isLoading, setIsLoading] = useState(false);
-    const isFirstRender = useRef(true);
+    const loadingTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+        undefined
+    );
 
     // Liste dérivée de l'état, donc disponible dès le rendu serveur
     const filteredEvents = useMemo(
@@ -54,16 +56,23 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({
         [events, period, originFilter]
     );
 
-    // Skeleton uniquement lors d'un changement de filtre, pas au chargement initial
-    useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-            return;
-        }
+    // Skeleton bref lors d'un changement de filtre, déclenché depuis les handlers
+    // (pas depuis un effet) pour éviter un rendu supplémentaire au montage.
+    const flashSkeleton = () => {
+        clearTimeout(loadingTimer.current);
         setIsLoading(true);
-        const timer = setTimeout(() => setIsLoading(false), 100);
-        return () => clearTimeout(timer);
-    }, [period, originFilter]);
+        loadingTimer.current = setTimeout(() => setIsLoading(false), 100);
+    };
+    useEffect(() => () => clearTimeout(loadingTimer.current), []);
+
+    const handlePeriodChange = (value: string) => {
+        setPeriod(value as EventPeriod);
+        flashSkeleton();
+    };
+    const handleOriginChange = (value: string) => {
+        setOriginFilter(value as EventOriginFilter);
+        flashSkeleton();
+    };
 
     return (
         <FadeInWrapper delay={0.2}>
@@ -72,12 +81,7 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({
                     {SECTION_TITLE[period]}
                 </h2>
                 <div className='flex justify-center px-6 w-full gap-3'>
-                    <Select
-                        value={period}
-                        onValueChange={(value) =>
-                            setPeriod(value as EventPeriod)
-                        }
-                    >
+                    <Select value={period} onValueChange={handlePeriodChange}>
                         <SelectTrigger className='w-full md:w-fit space-x-2'>
                             <SelectValue placeholder='Sélectionner les événements' />
                         </SelectTrigger>
@@ -96,9 +100,7 @@ const ClientEventFilter: React.FC<ClientEventFilterProps> = ({
 
                     <Select
                         value={originFilter}
-                        onValueChange={(value) =>
-                            setOriginFilter(value as EventOriginFilter)
-                        }
+                        onValueChange={handleOriginChange}
                     >
                         <SelectTrigger className='w-full md:w-fit space-x-2'>
                             <SelectValue placeholder="Origine de l'événement" />

--- a/app/(client)/events/_components/next-event-card.tsx
+++ b/app/(client)/events/_components/next-event-card.tsx
@@ -67,7 +67,7 @@ function NextEventCard({
                                 titlePersonality={
                                     event.personality?.title || ''
                                 }
-                                origin={(event as any)?.origin}
+                                origin={event.origin}
                                 imageFit={isSingle ? 'contain' : 'cover'}
                                 containerClassName={
                                     isSingle ? 'aspect-[16/9]' : undefined

--- a/app/(client)/events/page.tsx
+++ b/app/(client)/events/page.tsx
@@ -8,7 +8,7 @@ import { formatEventDates } from '@/lib/formatEventDate';
 import { getCurrentSeason } from '@/lib/getCurrentSeason';
 import { hasUpcomingEvents } from '@/lib/selectEventsByPeriod';
 import { sortEventsByDate } from '@/lib/sortEventsByDate';
-import { Evenement, EVENTS_QUERYResult } from '@/sanity.types';
+import { Evenement, EVENTS_QUERY_RESULT } from '@/sanity.types';
 import { sanityFetch } from '@/sanity/lib/fetch';
 import { urlFor } from '@/sanity/lib/imageUrl';
 import { EVENTS_QUERY } from '@/sanity/lib/queries';
@@ -18,7 +18,7 @@ import ClientEventFilter from './_components/event-filter';
 import { FeaturedEventImage } from './_components/featured-event-image';
 
 export default async function Events() {
-    const events: EVENTS_QUERYResult = await sanityFetch({
+    const events: EVENTS_QUERY_RESULT = await sanityFetch({
         query: EVENTS_QUERY,
     });
 
@@ -196,7 +196,7 @@ export default async function Events() {
                                 <FeaturedEventImage
                                     src={firstEventOrLatestImageUrl}
                                     alt={"Poster de l'événement"}
-                                    origin={(firstEventOrLatest as any)?.origin}
+                                    origin={firstEventOrLatest.origin}
                                 />
                             ) : null}
                         </div>

--- a/components/navigation-event.tsx
+++ b/components/navigation-event.tsx
@@ -11,7 +11,7 @@ import React, { Children, ReactElement, useEffect, useState } from 'react';
  */
 
 interface NavigationEventsProps {
-    children: ReactElement<any>;
+    children: ReactElement<{ hash?: string }>;
 }
 
 export function NavigationEvents({ children }: NavigationEventsProps) {

--- a/components/shared/fade-in-wrapper.tsx
+++ b/components/shared/fade-in-wrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion, useAnimation } from 'framer-motion';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const fadeInVariants = {
     hidden: (direction: string) => {
@@ -36,14 +36,14 @@ const FadeInWrapper: React.FC<FadeInWrapperProps> = ({
 }) => {
     const controls = useAnimation();
     const ref = useRef<HTMLDivElement>(null);
-    const [isMounted, setIsMounted] = useState(false);
 
+    // L'effet ne s'exécute que côté client, après montage : pas besoin d'un flag isMounted
     useEffect(() => {
         const element = ref.current;
 
         const observer = new IntersectionObserver(
             ([entry]) => {
-                if (entry.isIntersecting && isMounted) {
+                if (entry.isIntersecting) {
                     controls.start('visible');
                 }
             },
@@ -62,11 +62,7 @@ const FadeInWrapper: React.FC<FadeInWrapperProps> = ({
                 observer.unobserve(element);
             }
         };
-    }, [controls, isMounted]);
-
-    useEffect(() => {
-        setIsMounted(true);
-    }, []);
+    }, [controls]);
 
     return (
         <motion.div

--- a/components/shared/lord-icon.tsx
+++ b/components/shared/lord-icon.tsx
@@ -36,7 +36,7 @@ const LordIcon: React.FC<LordIconProps> = ({
                     if (colors) lordIcon.setAttribute('colors', colors);
                     if (style) {
                         Object.entries(style).forEach(([key, value]) => {
-                            // @ts-ignore
+                            // @ts-expect-error -- indexation dynamique de CSSStyleDeclaration
                             lordIcon.style[key] = value;
                         });
                     }

--- a/components/ui/3d-card.tsx
+++ b/components/ui/3d-card.tsx
@@ -115,7 +115,7 @@ export const CardItem = ({
     rotateX?: number | string;
     rotateY?: number | string;
     rotateZ?: number | string;
-    [key: string]: any;
+    [key: string]: unknown;
 }) => {
     const ref = useRef<HTMLDivElement>(null);
     const [isMouseEntered] = useMouseEnter();

--- a/components/ui/text-generate-effect.tsx
+++ b/components/ui/text-generate-effect.tsx
@@ -18,7 +18,7 @@ export const TextGenerateEffect = ({
 }) => {
     const [scope, animate] = useAnimate();
     const containerRef = useRef<HTMLDivElement>(null);
-    let wordsArray = words.split(' ');
+    const wordsArray = words.split(' ');
     useEffect(() => {
         const element = containerRef.current;
 

--- a/emails/confirmation-email.tsx
+++ b/emails/confirmation-email.tsx
@@ -151,7 +151,7 @@ export function ConfirmationEmail({
                                     lineHeight: '1.6',
                                 }}
                             >
-                                En attendant, n'hésitez pas à consulter notre
+                                En attendant, n&apos;hésitez pas à consulter notre
                                 site pour découvrir nos activités, nos cours et
                                 nos événements.
                             </Text>
@@ -199,7 +199,7 @@ export function ConfirmationEmail({
                                     marginBottom: '15px',
                                 }}
                             >
-                                Besoin d'informations ?
+                                Besoin d&apos;informations ?
                             </Text>
                             <Text
                                 style={{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+
+/**
+ * Configuration ESLint au format "flat" (ESLint 9+).
+ * Next.js 16 a retiré la commande `next lint` : le script `lint` appelle
+ * ESLint directement, et cette config remplace l'ancien `.eslintrc.json`.
+ */
+export default defineConfig([
+    ...nextVitals,
+    ...nextTs,
+    globalIgnores([
+        // Ignorés par défaut par eslint-config-next
+        '.next/**',
+        'out/**',
+        'build/**',
+        'next-env.d.ts',
+        // Spécifiques au projet
+        'ds-bundle/**', // export du design system, code généré
+        '.design-sync/**',
+        '.ds-sync/**', // outillage de synchronisation du design system
+        'sanity.types.ts', // généré par `sanity typegen`
+    ]),
+]);

--- a/hooks/use-outside-click.ts
+++ b/hooks/use-outside-click.ts
@@ -2,11 +2,11 @@ import React, { useEffect } from 'react';
 
 export const useOutsideClick = (
     ref: React.RefObject<HTMLDivElement | null>,
-    callback: Function
+    callback: (event: MouseEvent | TouchEvent) => void
 ) => {
     useEffect(() => {
-        const listener = (event: any) => {
-            if (!ref.current || ref.current.contains(event.target)) {
+        const listener = (event: MouseEvent | TouchEvent) => {
+            if (!ref.current || ref.current.contains(event.target as Node)) {
                 return;
             }
             callback(event);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "dev": "next dev --turbopack",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint",
+        "lint": "eslint .",
         "test": "node --test \"lib/**/*.test.ts\""
     },
     "dependencies": {

--- a/sanity-typegen.json
+++ b/sanity-typegen.json
@@ -1,0 +1,3 @@
+{
+    "overloadClientMethods": false
+}

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -13,6 +13,69 @@
  */
 
 // Source: schema.json
+export type SanityImageAssetReference = {
+  _ref: string;
+  _type: "reference";
+  _weak?: boolean;
+  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+};
+
+export type Evenement = {
+  _id: string;
+  _type: "evenement";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  slug?: Slug;
+  description?: string;
+  origin?: "internal" | "external";
+  externalUrl?: string;
+  mainImage?: {
+    asset?: SanityImageAssetReference;
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  eventDates?: Array<string>;
+  timeSlots?: Array<string>;
+  personality?: {
+    firstName?: string;
+    lastName?: string;
+    title?: string;
+    photo?: {
+      asset?: SanityImageAssetReference;
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+  };
+};
+
+export type SanityImageCrop = {
+  _type: "sanity.imageCrop";
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+};
+
+export type SanityImageHotspot = {
+  _type: "sanity.imageHotspot";
+  x?: number;
+  y?: number;
+  height?: number;
+  width?: number;
+};
+
+export type Slug = {
+  _type: "slug";
+  current?: string;
+  source?: string;
+};
+
 export type SanityImagePaletteSwatch = {
   _type: "sanity.imagePaletteSwatch";
   background?: string;
@@ -39,6 +102,18 @@ export type SanityImageDimensions = {
   aspectRatio?: number;
 };
 
+export type SanityImageMetadata = {
+  _type: "sanity.imageMetadata";
+  location?: Geopoint;
+  dimensions?: SanityImageDimensions;
+  palette?: SanityImagePalette;
+  lqip?: string;
+  blurHash?: string;
+  thumbHash?: string;
+  hasAlpha?: boolean;
+  isOpaque?: boolean;
+};
+
 export type SanityFileAsset = {
   _id: string;
   _type: "sanity.fileAsset";
@@ -61,67 +136,11 @@ export type SanityFileAsset = {
   source?: SanityAssetSourceData;
 };
 
-export type Geopoint = {
-  _type: "geopoint";
-  lat?: number;
-  lng?: number;
-  alt?: number;
-};
-
-export type Evenement = {
-  _id: string;
-  _type: "evenement";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  title?: string;
-  slug?: Slug;
-  description?: string;
-  mainImage?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-    hotspot?: SanityImageHotspot;
-    crop?: SanityImageCrop;
-    _type: "image";
-  };
-  eventDates?: Array<string>;
-  timeSlots?: Array<string>;
-  personality?: {
-    firstName?: string;
-    lastName?: string;
-    title?: string;
-    photo?: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
-  };
-};
-
-export type SanityImageCrop = {
-  _type: "sanity.imageCrop";
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-};
-
-export type SanityImageHotspot = {
-  _type: "sanity.imageHotspot";
-  x?: number;
-  y?: number;
-  height?: number;
-  width?: number;
+export type SanityAssetSourceData = {
+  _type: "sanity.assetSourceData";
+  name?: string;
+  id?: string;
+  url?: string;
 };
 
 export type SanityImageAsset = {
@@ -147,51 +166,53 @@ export type SanityImageAsset = {
   source?: SanityAssetSourceData;
 };
 
-export type SanityAssetSourceData = {
-  _type: "sanity.assetSourceData";
-  name?: string;
-  id?: string;
-  url?: string;
+export type Geopoint = {
+  _type: "geopoint";
+  lat?: number;
+  lng?: number;
+  alt?: number;
 };
 
-export type SanityImageMetadata = {
-  _type: "sanity.imageMetadata";
-  location?: Geopoint;
-  dimensions?: SanityImageDimensions;
-  palette?: SanityImagePalette;
-  lqip?: string;
-  blurHash?: string;
-  hasAlpha?: boolean;
-  isOpaque?: boolean;
-};
+export type AllSanitySchemaTypes =
+  | SanityImageAssetReference
+  | Evenement
+  | SanityImageCrop
+  | SanityImageHotspot
+  | Slug
+  | SanityImagePaletteSwatch
+  | SanityImagePalette
+  | SanityImageDimensions
+  | SanityImageMetadata
+  | SanityFileAsset
+  | SanityAssetSourceData
+  | SanityImageAsset
+  | Geopoint;
 
-export type Slug = {
-  _type: "slug";
-  current?: string;
-  source?: string;
-};
-
-export type AllSanitySchemaTypes = SanityImagePaletteSwatch | SanityImagePalette | SanityImageDimensions | SanityFileAsset | Geopoint | Evenement | SanityImageCrop | SanityImageHotspot | SanityImageAsset | SanityAssetSourceData | SanityImageMetadata | Slug;
 export declare const internalGroqTypeReferenceTo: unique symbol;
-// Source: ./sanity/lib/queries.ts
+
+type ArrayOf<T> = Array<
+  T & {
+    _key: string;
+  }
+>;
+
+// Source: sanity\lib\queries.ts
 // Variable: EVENTS_QUERY
 // Query: *[_type == "evenement" && defined(slug)]
-export type EVENTS_QUERYResult = Array<{
+export type EVENTS_QUERY_RESULT = Array<{
   _id: string;
   _type: "evenement";
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
   title?: string;
-  slug?: Slug;
+  slug: Slug;
   description?: string;
+  origin?: "external" | "internal";
+  externalUrl?: string;
   mainImage?: {
-    asset?: {
-      _ref: string;
-      _type: "reference";
-      _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
+    asset?: SanityImageAssetReference;
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -203,15 +224,48 @@ export type EVENTS_QUERYResult = Array<{
     lastName?: string;
     title?: string;
     photo?: {
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-      };
+      asset?: SanityImageAssetReference;
+      media?: unknown;
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       _type: "image";
     };
   };
 }>;
+
+// Source: sanity\lib\queries.ts
+// Variable: EVENT_QUERY
+// Query: *[_type == "evenement" && _id == $eventId][0]
+export type EVENT_QUERY_RESULT = {
+  _id: string;
+  _type: "evenement";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  title?: string;
+  slug?: Slug;
+  description?: string;
+  origin?: "external" | "internal";
+  externalUrl?: string;
+  mainImage?: {
+    asset?: SanityImageAssetReference;
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
+  eventDates?: Array<string>;
+  timeSlots?: Array<string>;
+  personality?: {
+    firstName?: string;
+    lastName?: string;
+    title?: string;
+    photo?: {
+      asset?: SanityImageAssetReference;
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+  };
+} | null;

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,380 @@
 [
   {
+    "type": "type",
+    "name": "sanity.imageAsset.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "sanity.imageAsset"
+    }
+  },
+  {
+    "name": "evenement",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "evenement"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "origin": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "internal"
+            },
+            {
+              "type": "string",
+              "value": "external"
+            }
+          ]
+        },
+        "optional": true
+      },
+      "externalUrl": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "mainImage": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageAsset.reference"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "eventDates": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "string"
+          }
+        },
+        "optional": true
+      },
+      "timeSlots": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "string"
+          }
+        },
+        "optional": true
+      },
+      "personality": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "firstName": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "lastName": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "title": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "photo": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageAsset.reference"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                }
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageCrop"
+          }
+        },
+        "top": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "bottom": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "left": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "right": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageHotspot"
+          }
+        },
+        "x": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "y": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "width": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        },
+        "current": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "sanity.imagePaletteSwatch",
     "type": "type",
     "value": {
@@ -153,6 +528,81 @@
     }
   },
   {
+    "name": "sanity.imageMetadata",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageMetadata"
+          }
+        },
+        "location": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "geopoint"
+          },
+          "optional": true
+        },
+        "dimensions": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "sanity.imageDimensions"
+          },
+          "optional": true
+        },
+        "palette": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "sanity.imagePalette"
+          },
+          "optional": true
+        },
+        "lqip": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "blurHash": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "thumbHash": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "hasAlpha": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        },
+        "isOpaque": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "sanity.fileAsset",
     "type": "document",
     "attributes": {
@@ -289,7 +739,7 @@
     }
   },
   {
-    "name": "geopoint",
+    "name": "sanity.assetSourceData",
     "type": "type",
     "value": {
       "type": "object",
@@ -298,348 +748,27 @@
           "type": "objectAttribute",
           "value": {
             "type": "string",
-            "value": "geopoint"
+            "value": "sanity.assetSourceData"
           }
         },
-        "lat": {
+        "name": {
           "type": "objectAttribute",
           "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "lng": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "alt": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "evenement",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "evenement"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "slug": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "slug"
-        },
-        "optional": true
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "mainImage": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "_ref": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "reference"
-                    }
-                  },
-                  "_weak": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "boolean"
-                    },
-                    "optional": true
-                  }
-                },
-                "dereferencesTo": "sanity.imageAsset"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "eventDates": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
             "type": "string"
-          }
+          },
+          "optional": true
         },
-        "optional": true
-      },
-      "timeSlots": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
+        "id": {
+          "type": "objectAttribute",
+          "value": {
             "type": "string"
-          }
-        },
-        "optional": true
-      },
-      "personality": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "firstName": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "lastName": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "title": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
-            },
-            "photo": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "object",
-                "attributes": {
-                  "asset": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "object",
-                      "attributes": {
-                        "_ref": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string"
-                          }
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "reference"
-                          }
-                        },
-                        "_weak": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "boolean"
-                          },
-                          "optional": true
-                        }
-                      },
-                      "dereferencesTo": "sanity.imageAsset"
-                    },
-                    "optional": true
-                  },
-                  "hotspot": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageHotspot"
-                    },
-                    "optional": true
-                  },
-                  "crop": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "inline",
-                      "name": "sanity.imageCrop"
-                    },
-                    "optional": true
-                  },
-                  "_type": {
-                    "type": "objectAttribute",
-                    "value": {
-                      "type": "string",
-                      "value": "image"
-                    }
-                  }
-                }
-              },
-              "optional": true
-            }
-          }
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "sanity.imageCrop",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageCrop"
-          }
-        },
-        "top": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
           },
           "optional": true
         },
-        "bottom": {
+        "url": {
           "type": "objectAttribute",
           "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "left": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "right": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageHotspot",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageHotspot"
-          }
-        },
-        "x": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "y": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
+            "type": "string"
           },
           "optional": true
         }
@@ -791,7 +920,7 @@
     }
   },
   {
-    "name": "sanity.assetSourceData",
+    "name": "geopoint",
     "type": "type",
     "value": {
       "type": "object",
@@ -800,125 +929,27 @@
           "type": "objectAttribute",
           "value": {
             "type": "string",
-            "value": "sanity.assetSourceData"
+            "value": "geopoint"
           }
         },
-        "name": {
+        "lat": {
           "type": "objectAttribute",
           "value": {
-            "type": "string"
+            "type": "number"
           },
           "optional": true
         },
-        "id": {
+        "lng": {
           "type": "objectAttribute",
           "value": {
-            "type": "string"
+            "type": "number"
           },
           "optional": true
         },
-        "url": {
+        "alt": {
           "type": "objectAttribute",
           "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageMetadata",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageMetadata"
-          }
-        },
-        "location": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "geopoint"
-          },
-          "optional": true
-        },
-        "dimensions": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imageDimensions"
-          },
-          "optional": true
-        },
-        "palette": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "sanity.imagePalette"
-          },
-          "optional": true
-        },
-        "lqip": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "blurHash": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "hasAlpha": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        },
-        "isOpaque": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "slug",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "slug"
-          }
-        },
-        "current": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
+            "type": "number"
           },
           "optional": true
         }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,10 @@
-const {
-    default: flattenColorPalette,
-} = require('tailwindcss/lib/util/flattenColorPalette');
+import typography from '@tailwindcss/typography';
+import tailwindScrollbar from 'tailwind-scrollbar';
 import type { Config } from 'tailwindcss';
-const { fontFamily } = require('tailwindcss/defaultTheme');
+import { fontFamily } from 'tailwindcss/defaultTheme';
+import flattenColorPalette from 'tailwindcss/lib/util/flattenColorPalette';
+import type { PluginAPI } from 'tailwindcss/types/config';
+import tailwindcssAnimate from 'tailwindcss-animate';
 
 const config = {
     darkMode: ['class'],
@@ -98,17 +100,17 @@ const config = {
         },
     },
     plugins: [
-        require('tailwindcss-animate'),
-        require('@tailwindcss/typography'),
-        require('tailwind-scrollbar'),
+        tailwindcssAnimate,
+        typography,
+        tailwindScrollbar,
         addVariablesForColors,
     ],
 } satisfies Config;
 
 // This plugin adds each Tailwind color as a global CSS variable, e.g. var(--gray-200).
-function addVariablesForColors({ addBase, theme }: any) {
-    let allColors = flattenColorPalette(theme('colors'));
-    let newVars = Object.fromEntries(
+function addVariablesForColors({ addBase, theme }: PluginAPI) {
+    const allColors = flattenColorPalette(theme('colors'));
+    const newVars = Object.fromEntries(
         Object.entries(allColors).map(([key, val]) => [`--${key}`, val])
     );
 

--- a/types/tailwindcss-flatten-color-palette.d.ts
+++ b/types/tailwindcss-flatten-color-palette.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Utilitaire interne de Tailwind v3, sans déclaration de types fournie.
+ * Aplatit la palette `theme('colors')` en paires `nom -> valeur CSS`
+ * (ex. `gray-200 -> #e5e7eb`). Utilisé par `addVariablesForColors`
+ * dans `tailwind.config.ts`.
+ */
+declare module 'tailwindcss/lib/util/flattenColorPalette' {
+    const flattenColorPalette: (colors: unknown) => Record<string, string>;
+    export default flattenColorPalette;
+}


### PR DESCRIPTION
## Types Sanity
`schema.json` datait d'avant l'ajout des champs `origin` et `externalUrl` : le type `Evenement` généré ne les connaissait pas et le code passait par `as any`. Schéma réextrait, types régénérés, 7 casts `as any` supprimés.

- Les types de requêtes s'appellent désormais `*_QUERY_RESULT` (nouveau nommage du typegen).
- `sanity-typegen.json` avec `overloadClientMethods: false` : l'augmentation de module `@sanity/client` générée n'est pas utilisée (les requêtes passent par `sanityFetch<T>`) et aurait demandé d'ajouter `@sanity/client` en dépendance directe.

## ESLint
`next lint` a été retiré dans Next.js 16 et `.eslintrc.json` est ignoré par ESLint 9 : `pnpm lint` ne pouvait plus tourner. Ajout de `eslint.config.mjs` (presets `core-web-vitals` + `typescript`, dossiers générés ignorés) et script `lint` sur `eslint .`.

Les 15 erreurs remontées sont corrigées sans changement de comportement :
- `tailwind.config.ts` : imports ESM au lieu de `require()`, API plugin typée, déclaration de module pour `flattenColorPalette` (non typé par Tailwind)
- `fade-in-wrapper` : suppression du flag `isMounted` redondant (l'effet `IntersectionObserver` ne tourne que côté client)
- `event-filter` : skeleton déclenché depuis les handlers des `Select` plutôt que depuis un effet
- types explicites à la place de `any` / `Function`, `prefer-const`, `@ts-expect-error`, apostrophes échappées dans l'email de confirmation

Restent 9 avertissements de variables inutilisées dans des fichiers hors sujet, non bloquants.

## Vérification
- `tsc --noEmit` OK, `pnpm lint` 0 erreur, `pnpm test` 8/8, `pnpm build` OK
- CSS généré vérifié : variables `--<couleur>` du plugin, `scrollbar-*` et `animate-*` toujours présents

🤖 Generated with [Claude Code](https://claude.com/claude-code)