### PR TITLE
fix(seo): name the training venue Gymnase Albert Camus

### DIFF
--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -6,8 +6,8 @@ const Footer = () => {
     return (
         <footer className='flex flex-col p-4 pb-28 md:pb-4 w-full font-serif'>
             <p className='text-center text-gray-400 text-sm font-normal'>
-                ©2024 - Association JKD Self Defense 31 à Muret (31600) - Salle
-                Albert Camus - Tous droits réservés
+                ©2024 - Association JKD Self Defense 31 à Muret (31600) -
+                Gymnase Albert Camus - Tous droits réservés
             </p>
             <div className='grid w-full grid-cols-1 md:grid-cols-[1fr_auto_1fr] items-center'>
                 {/* Colonne gauche (vide en desktop pour centrer le bloc central) */}

--- a/constant/config.ts
+++ b/constant/config.ts
@@ -9,7 +9,7 @@ export const associationConfig = {
      * À garder identique à la fiche Google Business Profile.
      */
     venue: {
-        name: 'Salle Albert Camus',
+        name: 'Gymnase Albert Camus',
         streetAddress: '6 Rue Pierre Bauduc',
         postalCode: '31600',
         city: 'Muret',

--- a/docs/reviews/2026-08-23-revue-qualite.md
+++ b/docs/reviews/2026-08-23-revue-qualite.md
@@ -57,7 +57,7 @@ Correspond aux tâches 1, 2 et 8 de [`../seo/technical/implementation-plan.md`](
 | Événements externes | Canonical et `url` JSON-LD = URL externe, pas d'`organizer` | La page est une republication ; la page d'origine fait référence. Choix hérité du commit "add external events", conservé. |
 | Rétention des événements passés dans le sitemap | 12 mois | Au-delà, aucun intérêt de référencement. |
 | Runner de tests | Vitest | `node --test` ne résout pas l'alias `@/` de `tsconfig`. Vitest le lit en une ligne de config et fonctionne sur un projet Next.js (Vite n'est que son moteur de transformation). |
-| Nom de la salle | "Salle Albert Camus" (pied de page) | Les descriptions d'événements disent "Gymnase Albert Camus". À trancher selon la fiche Google Business, puis aligner `constant/config.ts`. |
+| Nom de la salle | "Gymnase Albert Camus" | Nom officiel de l'équipement (annuaire de la mairie de Muret, FFME, Pages Jaunes). Le site disait "Salle", les descriptions d'événements "Gymnase". Tranché le 23 août 2026 : le nom sous lequel le lieu est référencé sur le web. |
 
 ### Changements de code
 
@@ -79,7 +79,7 @@ Correspond aux tâches 1, 2 et 8 de [`../seo/technical/implementation-plan.md`](
 
 | Document | `location` renseigné |
 |---|---|
-| 6 événements internes (`0f61c110`, `40d6963b`, `4fefbb49`, `541b342c`, `72723159`, `b8c3c7ba`) | Salle Albert Camus, 6 Rue Pierre Bauduc, 31600 Muret |
+| 6 événements internes (`0f61c110`, `40d6963b`, `4fefbb49`, `541b342c`, `72723159`, `b8c3c7ba`) | Gymnase Albert Camus, 6 Rue Pierre Bauduc, 31600 Muret (saisi "Salle" puis renommé "Gymnase" le même jour) |
 | `076fddca` Stage de printemps 2026 | Salle Mystère, complexe Jacqueline Auriol, 40 avenue Henri Peyrusse, 31600 Muret (lu dans la description) |
 | `d83cc058` Bootcamp Téléthon 2023 | Lac du Four de Louge, 31600 Muret (lu dans la description) |
 | 5 événements externes | **Non renseignés.** À saisir dans le Studio par Yann. |
@@ -92,7 +92,8 @@ Correspond aux tâches 1, 2 et 8 de [`../seo/technical/implementation-plan.md`](
 
 - [ ] Search Console : vérifier la propriété `https://www.jkd-selfdefense31.fr`, soumettre `/sitemap.xml`.
 - [ ] Studio Sanity : renseigner le lieu des 5 événements externes.
-- [ ] Fiche Google Business : trancher "Salle" ou "Gymnase" Albert Camus ; aligner nom, adresse, téléphone, horaires avec `constant/config.ts` (cohérence NAP).
+- [x] Fiche Google Business : nom "JKD Self Defense 31", adresse sans "Association Ji Dao", profils sociaux ajoutés (Yann, 23 août 2026). Reste : description, date de création, photos, vérification des horaires.
+- [ ] Pages Jaunes : la fiche "Ji Dao Self Defense Jeet Kune Do" porte l'ancien nom, à faire corriger.
 - [ ] Après quelques semaines : contrôler dans Search Console que `.com` et `vercel.app` disparaissent de l'index.
 
 ## Lots suivants (non commencés)

--- a/lib/structured-data.test.ts
+++ b/lib/structured-data.test.ts
@@ -15,7 +15,7 @@ const internalEvent: EventForJsonLd = {
     eventDates: ['2026-06-17', '2026-06-18'],
     origin: 'internal',
     location: {
-        name: 'Salle Albert Camus',
+        name: 'Gymnase Albert Camus',
         streetAddress: '6 Rue Pierre Bauduc',
         postalCode: '31600',
         city: 'Muret',
@@ -37,7 +37,7 @@ describe('buildEventJsonLd', () => {
         expect(ld.image).toBe('https://cdn.sanity.io/poster.jpg');
         expect(ld.location).toEqual({
             '@type': 'Place',
-            name: 'Salle Albert Camus',
+            name: 'Gymnase Albert Camus',
             address: {
                 '@type': 'PostalAddress',
                 streetAddress: '6 Rue Pierre Bauduc',


### PR DESCRIPTION
Le nom officiel de l'équipement est "Gymnase Albert Camus" (annuaire de la mairie de Muret, FFME, Pages Jaunes), le site disait "Salle". Alignement pour la cohérence NAP avec la fiche Google Business :

- `constant/config.ts` (`venue.name`) : alimente le JSON-LD `SportsActivityLocation`, le lieu des événements et les valeurs par défaut Sanity
- Pied de page du site
- Note de revue mise à jour (décision datée, actions fiche Google cochées, Pages Jaunes ajouté)

Les 6 événements internes Sanity ont été renommés en parallèle (dataset production).

Vérifié : `tsc`, `pnpm lint` 0 erreur, `pnpm test` 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)