### PR TITLE
SEO, accessibilité et annonce de rentrée 2026-2027

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,16 @@ yarn-error.log*
 next-env.d.ts
 .env*
 !.env.example
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+.design-sync/build/
+build/
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/.playwright/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Ce projet est le site web officiel de l'association **JKD Self Defense 31**, sit
 - **Nom** : JKD Self Defense 31
 - **Adresse** : 6 Rue Pierre Bauduc, 31600 Muret, France
 - **Téléphone** : +33 6 84 05 93 26
-- **Email** : president@jeetkunedo31.com
+- **Email** : contact@jkd-selfdefense31.fr
 - **Présidente** : Fanny GABORIT
 
 ### Disciplines enseignées

--- a/app/(client)/27-styles/_components/styles-animate-title.tsx
+++ b/app/(client)/27-styles/_components/styles-animate-title.tsx
@@ -12,43 +12,52 @@ export default function StylesAnimateTitle() {
 
     return (
         <header className='flex flex-col items-center max-md:mb-4 md:h-36'>
-            {isDesktop ? (
-                <>
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white md:text-4xl'
-                        text='Les 27 styles qui ont influencés'
-                    />
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white md:text-4xl'
-                        text='Bruce LEE pour le Jeet Kune Do'
-                        onAnimationComplete={() =>
-                            setIsFirstAnimationComplete(true)
-                        }
-                    />
-                </>
-            ) : (
-                <>
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white text-3xl'
-                        text='Les 27 styles'
-                    />
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white text-3xl'
-                        text='qui ont influencés'
-                    />
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white text-3xl'
-                        text='Bruce LEE pour'
-                    />
-                    <GradualSpacing
-                        className='max-md:text-center font-cinzel text-white text-3xl'
-                        text='le Jeet Kune Do'
-                        onAnimationComplete={() =>
-                            setIsFirstAnimationComplete(true)
-                        }
-                    />
-                </>
-            )}
+            {/*
+                Le titre est découpé en deux ou quatre fragments animés selon la
+                largeur d'écran. Un seul `h1` les enveloppe : son nom accessible
+                est la concaténation des fragments, et la page garde un titre
+                unique. Le `h1` reprend la mise en page du `header` pour que rien
+                ne bouge à l'écran.
+            */}
+            <h1 className='flex flex-col items-center'>
+                {isDesktop ? (
+                    <>
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white md:text-4xl'
+                            text='Les 27 styles qui ont influencés'
+                        />
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white md:text-4xl'
+                            text='Bruce LEE pour le Jeet Kune Do'
+                            onAnimationComplete={() =>
+                                setIsFirstAnimationComplete(true)
+                            }
+                        />
+                    </>
+                ) : (
+                    <>
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white text-3xl'
+                            text='Les 27 styles'
+                        />
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white text-3xl'
+                            text='qui ont influencés'
+                        />
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white text-3xl'
+                            text='Bruce LEE pour'
+                        />
+                        <GradualSpacing
+                            className='max-md:text-center font-cinzel text-white text-3xl'
+                            text='le Jeet Kune Do'
+                            onAnimationComplete={() =>
+                                setIsFirstAnimationComplete(true)
+                            }
+                        />
+                    </>
+                )}
+            </h1>
 
             <div className='h-14'>
                 {isFirstAnimationComplete && (

--- a/app/(client)/27-styles/layout.tsx
+++ b/app/(client)/27-styles/layout.tsx
@@ -3,23 +3,23 @@ import { Metadata } from 'next';
 import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-    title: "27 styles d'arts martiaux - JKD Self Defense 31",
+    title: "Les 27 styles qui ont influencé Bruce Lee",
     description:
-        'Les 27 Styles qui ont influencés Bruce Lee pour le Jeet Kune Do - JKD Self Defense 31 à Muret.',
+        "Les 27 styles d'arts martiaux qui ont influencé Bruce Lee dans la construction du Jeet Kune Do, présentés par le club JKD Self Defense 31 à Muret.",
     keywords:
         '27 Styles arts martiaux Jeet Kune Do, self-défense Toulouse Muret',
     alternates: { canonical: '/27-styles' },
     openGraph: {
-        title: "27 styles d'arts martiaux - JKD Self Defense 31",
+        title: "Les 27 styles qui ont influencé Bruce Lee | JKD Self Defense 31",
         description:
-            'Les 27 Styles qui ont influencés Bruce Lee pour le Jeet Kune Do - JKD Self Defense 31 à Muret.',
+            "Les 27 styles d'arts martiaux qui ont influencé Bruce Lee dans la construction du Jeet Kune Do, présentés par le club JKD Self Defense 31 à Muret.",
         url: absoluteUrl('/27-styles'),
     },
     twitter: {
         card: 'summary_large_image',
-        title: "27 styles d'arts martiaux - JKD Self Defense 31",
+        title: "Les 27 styles qui ont influencé Bruce Lee | JKD Self Defense 31",
         description:
-            'Les 27 Styles qui ont influencés Bruce Lee pour le Jeet Kune Do - JKD Self Defense 31 à Muret.',
+            "Les 27 styles d'arts martiaux qui ont influencé Bruce Lee dans la construction du Jeet Kune Do, présentés par le club JKD Self Defense 31 à Muret.",
     },
 };
 

--- a/app/(client)/association/layout.tsx
+++ b/app/(client)/association/layout.tsx
@@ -2,22 +2,26 @@ import { absoluteUrl } from '@/constant/site';
 import { Metadata } from 'next';
 import { ReactNode } from 'react';
 
+// Le suffixe de marque vient du gabarit défini dans `app/(client)/layout.tsx`.
+// Il n'est répété ici que dans Open Graph et Twitter, qui n'ont pas de gabarit.
 export const metadata: Metadata = {
-    title: 'Notre Association - JKD Self Defense 31',
+    title: 'Notre club d’arts martiaux à Muret',
     description:
-        'Découvrez notre association et son histoire, nos valeurs et notre équipe.',
+        "L'association JKD Self Defense 31 enseigne le Jeet Kune Do à Muret depuis 1998. Son histoire, sa pédagogie sans compétition et ses instructeurs.",
     keywords:
         'association JKD Self Defense 31, Jeet Kune Do, arts martiaux, Toulouse, Muret',
     alternates: { canonical: '/association' },
     openGraph: {
-        title: 'Notre Association - JKD Self Defense 31',
-        description: 'Tout savoir sur notre association et son engagement.',
+        title: 'Notre club d’arts martiaux à Muret | JKD Self Defense 31',
+        description:
+            "L'association JKD Self Defense 31 enseigne le Jeet Kune Do à Muret depuis 1998. Son histoire, sa pédagogie et ses instructeurs.",
         url: absoluteUrl('/association'),
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'Notre Association - JKD Self Defense 31',
-        description: 'Découvrez notre association, ses membres et ses valeurs.',
+        title: 'Notre club d’arts martiaux à Muret | JKD Self Defense 31',
+        description:
+            "L'association JKD Self Defense 31 enseigne le Jeet Kune Do à Muret depuis 1998. Son histoire, sa pédagogie et ses instructeurs.",
     },
 };
 

--- a/app/(client)/contact/layout.tsx
+++ b/app/(client)/contact/layout.tsx
@@ -3,23 +3,23 @@ import { Metadata } from 'next';
 import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-    title: 'Contactez-nous - JKD Self Defense 31',
+    title: 'Contacter le club à Muret',
     description:
-        "N'hésitez pas à nous contacter pour toute question sur nos cours de Jeet Kune Do ou pour rejoindre l'association JKD Self Defense 31 à Muret.",
+        "Une question avant de venir essayer le Jeet Kune Do ou la self-défense à Muret ? Écrivez au club ou appelez le 06 84 05 93 26. Débutants bienvenus.",
     keywords:
         'contact Jeet Kune Do, prix cours arts martiaux, self-défense Toulouse Muret',
     alternates: { canonical: '/contact' },
     openGraph: {
-        title: 'Contactez-nous - JKD Self Defense 31',
+        title: 'Contacter le club à Muret | JKD Self Defense 31',
         description:
-            "N'hésitez pas à nous contacter pour toute question sur nos cours de Jeet Kune Do ou pour rejoindre l'association JKD Self Defense 31 à Muret.",
+            "Une question avant de venir essayer le Jeet Kune Do ou la self-défense à Muret ? Écrivez au club ou appelez le 06 84 05 93 26.",
         url: absoluteUrl('/contact'),
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'Contactez-nous - JKD Self Defense 31',
+        title: 'Contacter le club à Muret | JKD Self Defense 31',
         description:
-            "N'hésitez pas à nous contacter pour toute question sur nos cours de Jeet Kune Do ou pour rejoindre l'association JKD Self Defense 31 à Muret.",
+            "Une question avant de venir essayer le Jeet Kune Do ou la self-défense à Muret ? Écrivez au club ou appelez le 06 84 05 93 26.",
     },
 };
 

--- a/app/(client)/contact/page.tsx
+++ b/app/(client)/contact/page.tsx
@@ -18,6 +18,7 @@ export default function Contact() {
                     className='max-md:hidden md:absolute inset-0 z-0 object-contain md:object-cover object-center lg:object-top brightness-50'
                 />
                 <GradualSpacing
+                    as='h1'
                     className='max-md:text-center font-cinzel text-white text-3xl'
                     text='Contactez nous'
                 />

--- a/app/(client)/events/[eventId]/page.tsx
+++ b/app/(client)/events/[eventId]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     }
 
     const imageUrl = event.mainImage?.asset?._ref
-        ? urlFor(event.mainImage.asset._ref).width(1200).height(630).url()
+        ? urlFor(event.mainImage).width(1200).height(630).url()
         : undefined;
     const isExternal = event.origin === 'external';
     const externalUrl = event.externalUrl;

--- a/app/(client)/events/_components/event-detail.tsx
+++ b/app/(client)/events/_components/event-detail.tsx
@@ -19,10 +19,10 @@ interface EventDetailProps {
 
 export default function EventDetail({ event }: EventDetailProps) {
     const imageUrl = event.mainImage?.asset?._ref
-        ? urlFor(event.mainImage.asset._ref).url()
+        ? urlFor(event.mainImage).url()
         : undefined;
     const personalityPhotoUrl = event.personality?.photo?.asset?._ref
-        ? urlFor(event.personality.photo.asset._ref).url()
+        ? urlFor(event.personality.photo).url()
         : '';
     const formattedEventDates = formatEventDates(event.eventDates);
     const isExternal = event.origin === 'external';

--- a/app/(client)/events/_components/next-event-card.tsx
+++ b/app/(client)/events/_components/next-event-card.tsx
@@ -45,11 +45,11 @@ function NextEventCard({
                 >
                     {events.map((event) => {
                         const mainImageUrl = event.mainImage?.asset?._ref
-                            ? urlFor(event.mainImage.asset._ref).url()
+                            ? urlFor(event.mainImage).url()
                             : '';
                         const personalityPhotoUrl = event.personality?.photo
                             ?.asset?._ref
-                            ? urlFor(event.personality.photo.asset._ref).url()
+                            ? urlFor(event.personality.photo).url()
                             : '';
 
                         const isSingle = events.length === 1;

--- a/app/(client)/events/layout.tsx
+++ b/app/(client)/events/layout.tsx
@@ -19,20 +19,20 @@ export async function generateMetadata(): Promise<Metadata> {
     const nextEvent = await getNextEvent();
     // Visuel du prochain événement, sinon l'image Open Graph du site
     const imageUrl = nextEvent?.mainImage?.asset?._ref
-        ? urlFor(nextEvent.mainImage.asset._ref).width(1200).height(630).url()
+        ? urlFor(nextEvent.mainImage).width(1200).height(630).url()
         : absoluteUrl('/opengraph-image.png');
 
     return {
-        title: 'Événements - JKD Self Defense 31',
+        title: 'Stages et événements du club à Muret',
         description:
-            "Restez informé des prochains événements, stages et démonstrations organisés par l'association JKD Self Defense 31 à Muret.",
+            "Stages, démonstrations et rendez-vous de l'association JKD Self Defense 31 à Muret. Dates, horaires, lieux et intervenants de la saison.",
         keywords:
             'événements Jeet Kune Do, stages arts martiaux et self defense, JKD Self Defense 31 Toulouse',
         alternates: { canonical: '/events' },
     openGraph: {
-            title: 'Événements - JKD Self Defense 31',
+            title: 'Stages et événements du club à Muret | JKD Self Defense 31',
             description:
-                "Restez informé des prochains événements, stages et démonstrations organisés par l'association JKD Self Defense 31 à Muret.",
+                "Stages, démonstrations et rendez-vous de l'association JKD Self Defense 31 à Muret. Dates, horaires, lieux et intervenants de la saison.",
             url: absoluteUrl('/events'),
             images: [
                 {
@@ -45,9 +45,9 @@ export async function generateMetadata(): Promise<Metadata> {
         },
         twitter: {
             card: 'summary_large_image',
-            title: 'Événements - JKD Self Defense 31',
+            title: 'Stages et événements du club à Muret | JKD Self Defense 31',
             description:
-                "Restez informé des prochains événements, stages et démonstrations organisés par l'association JKD Self Defense 31 à Muret.",
+                "Stages, démonstrations et rendez-vous de l'association JKD Self Defense 31 à Muret. Dates, horaires, lieux et intervenants de la saison.",
             images: [imageUrl],
         },
     };

--- a/app/(client)/events/page.tsx
+++ b/app/(client)/events/page.tsx
@@ -28,6 +28,7 @@ export default async function Events() {
             <section className='w-full max-md:pb-28'>
                 <header className='flex flex-col items-center align-center space-y-2 pb-10'>
                     <GradualSpacing
+                        as='h1'
                         text='Événements'
                         className='text-center text-3xl pt-10 md:pt-32 uppercase font-bold'
                     />
@@ -79,6 +80,7 @@ export default async function Events() {
             <section className='w-full max-md:pb-28'>
                 <header className='flex flex-col items-center align-center space-y-2 pb-10'>
                     <GradualSpacing
+                        as='h1'
                         text='Événements'
                         className='text-center text-3xl pt-10 md:pt-32 uppercase font-bold'
                     />
@@ -131,6 +133,7 @@ export default async function Events() {
         <section className='w-full max-md:pb-28'>
             <header className='flex flex-col items-center align-center space-y-2 pb-10'>
                 <GradualSpacing
+                    as='h1'
                     text='Événements'
                     className='text-center text-3xl pt-10 md:pt-32 uppercase font-bold'
                 />

--- a/app/(client)/layout.tsx
+++ b/app/(client)/layout.tsx
@@ -52,9 +52,15 @@ const cinzelDecorative = FontCinzelDecorative({
 export const metadata: Metadata = {
     metadataBase: new URL(SITE.url),
     alternates: { canonical: '/' },
-    title: 'Jeet Kune Do Toulouse - Arts Martiaux et Self-Défense',
+    title: {
+        // `default` est le titre de l'accueil et le repli des routes sans titre.
+        // `template` est hérité par toutes les routes filles, y compris les
+        // fiches événement de Sanity, qui n'affichaient pas le nom du club.
+        default: 'Jeet Kune Do et self-défense à Muret | JKD Self Defense 31',
+        template: '%s | JKD Self Defense 31',
+    },
     description:
-        "Découvrez le Jeet Kune Do à Muret avec l'association JKD Self Defense 31. Cours d'arts martiaux, de self-défense et de développement physique pour tous les niveaux.",
+        'Club de Jeet Kune Do, Kali, Silat et self-défense à Muret, au sud de Toulouse. Cours adultes, ados et self-défense féminine, tous niveaux, sans compétition.',
     keywords: [
         'Jeet Kune Do',
         'arts martiaux',
@@ -66,9 +72,9 @@ export const metadata: Metadata = {
         'JKD Self Defense 31',
     ],
     openGraph: {
-        title: 'Jeet Kune Do Toulouse - Arts Martiaux et Self-Défense',
+        title: 'Jeet Kune Do et self-défense à Muret | JKD Self Defense 31',
         description:
-            'Apprenez le Jeet Kune Do avec JKD Self Defense 31 à Muret. Cours adaptés à tous les niveaux.',
+            'Club de Jeet Kune Do, Kali, Silat et self-défense à Muret. Cours adultes, ados et self-défense féminine, tous niveaux.',
         url: SITE.url,
         locale: SITE.locale,
         siteName: 'JKD Self Defense 31 - Arts Martiaux et Self-Défense',
@@ -83,9 +89,9 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'Jeet Kune Do Toulouse - Arts Martiaux et Self-Défense',
+        title: 'Jeet Kune Do et self-défense à Muret | JKD Self Defense 31',
         description:
-            'Découvrez le Jeet Kune Do avec JKD Self Defense 31 à Toulouse.',
+            'Club de Jeet Kune Do, Kali, Silat et self-défense à Muret, au sud de Toulouse.',
         images: ['/opengraph-image.png'],
     },
 };
@@ -114,10 +120,18 @@ export default function RootLayout({
                 <JsonLd data={buildOrganizationJsonLd()} />
                 <JsonLd data={buildWebSiteJsonLd()} />
                 <JsonLd data={buildSportsLocationJsonLd()} />
+                {/*
+                    `forcedTheme` et non `defaultTheme` : le site est conçu en
+                    sombre uniquement, et `components/ui/mode-toggle.tsx` n'est
+                    rendu nulle part. Avec `enableSystem`, une clé `theme`
+                    laissée dans `localStorage` par une visite précédente, ou par
+                    un autre projet servi sur `localhost:3000`, suffisait à
+                    basculer tout le site en clair. Vérifié dans
+                    `e2e/rendu.spec.ts`.
+                */}
                 <ThemeProvider
                     attribute='class'
-                    defaultTheme='dark'
-                    enableSystem
+                    forcedTheme='dark'
                     disableTransitionOnChange
                     enableColorScheme={false}
                 >

--- a/app/(client)/legal/_components/legal-header.tsx
+++ b/app/(client)/legal/_components/legal-header.tsx
@@ -7,6 +7,7 @@ export default function LegalHeader() {
     return (
         <header className='flex flex-col items-center justify-center'>
             <GradualSpacing
+                as='h1'
                 className='max-md:text-center font-cinzel text-white text-3xl md:text-4xl'
                 text='Mentions Légales'
             />

--- a/app/(client)/legal/layout.tsx
+++ b/app/(client)/legal/layout.tsx
@@ -3,21 +3,21 @@ import { Metadata } from 'next';
 import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
-    title: 'Mentions légales - JKD Self Defense 31',
+    title: 'Mentions légales',
     description:
         "Mentions légales du site de l'association JKD Self Defense 31 à Muret.",
     keywords:
         'mentions légales Jeet Kune Do, prix cours arts martiaux, self-défense Toulouse Muret',
     alternates: { canonical: '/legal' },
     openGraph: {
-        title: 'Mentions légales - JKD Self Defense 31',
+        title: 'Mentions légales | JKD Self Defense 31',
         description:
             "Mentions légales du site de l'association JKD Self Defense 31 à Muret.",
         url: absoluteUrl('/legal'),
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'Mentions légales - JKD Self Defense 31',
+        title: 'Mentions légales | JKD Self Defense 31',
         description:
             "Mentions légales du site de l'association JKD Self Defense 31 à Muret.",
     },

--- a/app/(client)/page.tsx
+++ b/app/(client)/page.tsx
@@ -1,16 +1,47 @@
+import SeasonAnnouncement from '@/components/shared/season-announcement';
 import HomeTitle from './(home)/_components/home-title';
 import HomeContent from './(home)/home-content';
+
+/**
+ * L'annonce de rentrée a une fenêtre d'affichage. Sans revalidation, la page
+ * étant statique, la fenêtre serait figée à l'heure du build et l'annonce
+ * resterait en ligne après sa date de fin.
+ */
+export const revalidate = 3600;
 
 export default function Home() {
     return (
         <div>
             <header
-                className='h-screen w-full bg-contain md:bg-cover bg-no-repeat bg-center md:bg-top'
+                className='relative h-screen w-full bg-contain md:bg-cover bg-no-repeat bg-center md:bg-top'
                 style={{
                     backgroundImage: `url(/images/content/home/home-background.webp)`,
                 }}
             >
+                {/*
+                    Le visuel d'accueil est un logo, il ne porte aucun texte.
+                    Le titre de page n'existe donc que pour les robots et les
+                    lecteurs d'écran. C'est la cible de « Jeet Kune Do Muret ».
+                    Le rendre visible demanderait de redessiner le héros.
+                */}
+                <h1 className='sr-only'>
+                    Jeet Kune Do et self-défense à Muret
+                </h1>
                 <HomeTitle />
+                {/*
+                    L'annonce occupe le bas du héros, resté vide par construction.
+                    Positionnée en absolu : elle ne décale aucun bloc existant et
+                    disparaît d'elle-même hors de sa fenêtre d'affichage.
+                    `bottom-40` sur mobile passe au-dessus de la barre de
+                    navigation basse et du bouton flottant « Notre démo »,
+                    tous deux en `fixed bottom-24`.
+                */}
+                <div className='absolute inset-x-0 bottom-40 flex justify-center px-6 md:bottom-[8%] md:left-[5%] md:right-auto md:justify-start md:px-0'>
+                    <SeasonAnnouncement
+                        ctaLabel='Horaires, tarifs et lieu des cours'
+                        ctaHref='/tarifs'
+                    />
+                </div>
             </header>
             <HomeContent />
         </div>

--- a/app/(client)/tarifs/layout.tsx
+++ b/app/(client)/tarifs/layout.tsx
@@ -2,24 +2,27 @@ import { absoluteUrl } from '@/constant/site';
 import { Metadata } from 'next';
 import { ReactNode } from 'react';
 
+// La description reprenait mot pour mot celle de `/association`. Corrigée le
+// 30 août 2026 : c'est la deuxième page la plus consultée du site, et celle où
+// se prend la décision de venir essayer.
 export const metadata: Metadata = {
-    title: 'Tarifs des cours - JKD Self Defense 31',
+    title: 'Tarifs et horaires des cours à Muret',
     description:
-        'Découvrez notre association et son histoire, nos valeurs et notre équipe.',
+        'Tarifs, horaires et lieu des cours de Jeet Kune Do, JKD Boxing, Jun Fan conditioning et self-défense féminine à Muret. Licence et adhésion comprises.',
     keywords:
         'tarifs Jeet Kune Do, prix cours arts martiaux, self-défense Toulouse Muret',
     alternates: { canonical: '/tarifs' },
     openGraph: {
-        title: 'Tarifs des cours - JKD Self Defense 31',
+        title: 'Tarifs et horaires des cours à Muret | JKD Self Defense 31',
         description:
-            'Découvrez les tarifs de nos cours, les horaires et réductions.',
+            'Tarifs, horaires et lieu des cours de Jeet Kune Do, JKD Boxing, conditioning et self-défense féminine à Muret.',
         url: absoluteUrl('/tarifs'),
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'Tarifs des cours - JKD Self Defense 31',
+        title: 'Tarifs et horaires des cours à Muret | JKD Self Defense 31',
         description:
-            'Découvrez les tarifs de nos cours, les horaires et réductions.',
+            'Tarifs, horaires et lieu des cours de Jeet Kune Do, JKD Boxing, conditioning et self-défense féminine à Muret.',
     },
 };
 

--- a/app/(client)/tarifs/page.tsx
+++ b/app/(client)/tarifs/page.tsx
@@ -1,4 +1,5 @@
 import FadeInWrapper from '@/components/shared/fade-in-wrapper';
+import SeasonAnnouncement from '@/components/shared/season-announcement';
 import SportSvg from '@/components/svg/sport-svg';
 import GradualSpacing from '@/components/ui/gradual-spacing';
 import coursesData from '@/data/courses.json';
@@ -7,6 +8,12 @@ import { CourseData } from '@/types/specific-types';
 import CoursesTable from './_components/courses-table';
 import FindUs from './_components/find-us';
 import PriceShow from './_components/price-show';
+
+/**
+ * Comme l'accueil, cette page porte l'annonce de rentrée : sa fenêtre
+ * d'affichage a besoin d'une revalidation pour ne pas rester figée au build.
+ */
+export const revalidate = 3600;
 
 export default function Prices() {
     const courseData: CourseData = coursesData;
@@ -21,8 +28,14 @@ export default function Prices() {
             {/* Les cours */}
             <header className='flex flex-col items-center gap-2 pb-10 pt-10 md:pt-28'>
                 <GradualSpacing
+                    as='h1'
                     className='text-5xl max-md:text-center md:text-6xl font-bold leading-none md:max-w-xl'
                     text='Les cours'
+                />
+                <SeasonAnnouncement
+                    ctaLabel='Nous poser une question'
+                    ctaHref='/contact'
+                    className='mt-6'
                 />
             </header>
             <article className='flex flex-col-reverse md:flex-col md:gap-8 max-md:border-b-2 max-md:pb-8 max-md:border-dashed'>
@@ -45,6 +58,7 @@ export default function Prices() {
             {/* Détails des tarifs réduits */}
             <article className='flex flex-col items-center justify-center max-md:gap-4'>
                 <GradualSpacing
+                    as='h2'
                     text='Détails des tarifs réduits'
                     className='text-center text-2xl md:text-3xl font-bold leading-none md:max-w-xl'
                 />
@@ -54,6 +68,7 @@ export default function Prices() {
             {/* Nous trouver */}
             <article className='flex flex-col items-center justify-center gap-4 md:gap-12 bg-gray-900 pt-12 md:pt-24 pb-16 md:pb-24 h-full'>
                 <GradualSpacing
+                    as='h2'
                     text='Nous trouver'
                     className='text-center text-2xl md:text-3xl font-bold leading-none md:max-w-xl'
                 />

--- a/components/shared/avatar-personality.test.tsx
+++ b/components/shared/avatar-personality.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import AvatarPersonality from './avatar-personality';
+
+describe('AvatarPersonality', () => {
+    it('ne rend rien quand aucune personnalité n’est saisie', () => {
+        expect(renderToStaticMarkup(<AvatarPersonality />)).toBe('');
+    });
+
+    it('ne rend rien quand les champs arrivent vides depuis Sanity', () => {
+        const html = renderToStaticMarkup(
+            <AvatarPersonality firstName='' lastName='' title='' />
+        );
+        expect(html).toBe('');
+    });
+
+    it('n’affiche jamais de texte de substitution', () => {
+        const html = renderToStaticMarkup(<AvatarPersonality />);
+        expect(html).not.toContain('N/A');
+        expect(html).not.toContain('Unknown Title');
+    });
+
+    it('affiche le nom complet quand il est connu', () => {
+        const html = renderToStaticMarkup(
+            <AvatarPersonality
+                firstName='David'
+                lastName='DELANNOY'
+                title='Instructeur'
+            />
+        );
+        expect(html).toContain('David DELANNOY');
+        expect(html).toContain('Instructeur');
+    });
+
+    it('accepte un prénom sans nom, sans espace parasite', () => {
+        const html = renderToStaticMarkup(<AvatarPersonality firstName='Dan' />);
+        expect(html).toContain('>Dan<');
+    });
+
+    it('omet le titre quand il n’est pas renseigné', () => {
+        const html = renderToStaticMarkup(
+            <AvatarPersonality firstName='Dan' lastName='INOSANTO' />
+        );
+        expect(html).toContain('Dan INOSANTO');
+        expect(html).not.toContain('text-gray-400');
+    });
+});

--- a/components/shared/avatar-personality.tsx
+++ b/components/shared/avatar-personality.tsx
@@ -8,28 +8,41 @@ interface AvatarPersonalityProps {
     avatarClassName?: string;
 }
 
+/**
+ * Intervenant d'un événement.
+ *
+ * Ne rend rien tant qu'aucun nom n'est connu. Les valeurs de substitution
+ * précédentes (`N/A`, `Unknown Title`) s'affichaient telles quelles sur les
+ * événements sans personnalité saisie dans le Studio. Même règle que pour les
+ * données structurées : un champ inconnu est omis, jamais remplacé.
+ */
 function AvatarPersonality({
     personalityPhotoUrl = '',
-    firstName = 'N/A',
-    lastName = 'N/A',
-    title = 'Unknown Title',
+    firstName = '',
+    lastName = '',
+    title = '',
     avatarClassName = '',
 }: AvatarPersonalityProps) {
+    const fullName = [firstName.trim(), lastName.trim()]
+        .filter(Boolean)
+        .join(' ');
+
+    if (!fullName) return null;
+
     return (
         <div className='flex items-center mt-4'>
             <Avatar className={avatarClassName}>
                 {personalityPhotoUrl ? (
-                    <AvatarImage
-                        src={personalityPhotoUrl}
-                        alt={`${firstName} ${lastName}`}
-                    />
+                    <AvatarImage src={personalityPhotoUrl} alt={fullName} />
                 ) : (
-                    <AvatarFallback>{firstName.charAt(0)}</AvatarFallback>
+                    <AvatarFallback>{fullName.charAt(0)}</AvatarFallback>
                 )}
             </Avatar>
             <div className='ml-4'>
-                <p className='font-bold text-white'>{`${firstName} ${lastName}`}</p>
-                <p className='text-gray-400'>{title}</p>
+                <p className='font-bold text-white'>{fullName}</p>
+                {title.trim() ? (
+                    <p className='text-gray-400'>{title}</p>
+                ) : null}
             </div>
         </div>
     );

--- a/components/shared/menu.tsx
+++ b/components/shared/menu.tsx
@@ -23,7 +23,7 @@ export const navData = [
         mobileName: 'Accueil',
         path: '/',
         icon: <House />,
-        ariaLabel: 'Aller à la page d’accueil',
+        hint: 'page d’accueil',
     },
     {
         id: 2,
@@ -31,7 +31,7 @@ export const navData = [
         mobileName: "L'Asso",
         path: '/association',
         icon: <Ribbon />,
-        ariaLabel: 'Découvrir l’association',
+        hint: 'découvrir l’association',
     },
     {
         id: 3,
@@ -39,7 +39,7 @@ export const navData = [
         mobileName: 'Tarifs',
         path: '/tarifs',
         icon: <GraduationCap />,
-        ariaLabel: 'Tarifs des cours',
+        hint: 'tarifs et horaires des cours',
     },
     {
         id: 4,
@@ -47,7 +47,7 @@ export const navData = [
         mobileName: 'Events',
         path: '/events',
         icon: <CalendarSearch />,
-        ariaLabel: 'Aller à la page des événements',
+        hint: 'stages et actualités du club',
     },
     {
         id: 5,
@@ -55,7 +55,7 @@ export const navData = [
         mobileName: 'Contact',
         path: '/contact',
         icon: <Phone />,
-        ariaLabel: 'Aller à la section contact',
+        hint: 'nous écrire ou nous appeler',
     },
 ];
 
@@ -123,7 +123,7 @@ const Nav = ({ hash }: NavProps) => {
                         </TransitionLink> */}
                         <TransitionLink
                             href='/'
-                            aria-label='accueil'
+                            aria-label='Accueil, Jeet Kune Do, Kali, Silat, Self-défense'
                             className='group'
                         >
                             <GradualSpacing
@@ -137,7 +137,7 @@ const Nav = ({ hash }: NavProps) => {
                                     className={getLinkClassName(link.path)}
                                     href={link.path}
                                     key={link.id}
-                                    aria-label={link.ariaLabel}
+                                    aria-label={`${link.name}, ${link.hint}`}
                                     aria-current={
                                         hash === link.path ? 'page' : undefined
                                     }
@@ -157,12 +157,12 @@ const Nav = ({ hash }: NavProps) => {
                         return (
                             <TransitionLink
                                 className={cn(
-                                    'flex flex-col w-12',
+                                    'flex flex-col justify-center w-12 min-h-11',
                                     getLinkClassName(link.path)
                                 )}
                                 href={link.path}
                                 key={link.id}
-                                aria-label={link.ariaLabel}
+                                aria-label={`${link.mobileName}, ${link.hint}`}
                                 aria-current={
                                     hash === link.path ? 'page' : undefined
                                 }

--- a/components/shared/season-announcement.tsx
+++ b/components/shared/season-announcement.tsx
@@ -1,0 +1,59 @@
+import { SEASON_ANNOUNCEMENT } from '@/constant/announcement';
+import { selectVisibleAnnouncement } from '@/lib/announcement';
+import { cn } from '@/lib/utils';
+import { ArrowRight } from 'lucide-react';
+import { TransitionLink } from './transition-link';
+
+type SeasonAnnouncementProps = {
+    /** Destination du lien. Le libellé doit décrire cette destination. */
+    ctaLabel: string;
+    ctaHref: string;
+    className?: string;
+};
+
+/**
+ * Annonce de saison. Composant serveur : le texte est dans le HTML rendu, donc
+ * lisible par les robots qui n'exécutent pas JavaScript, et rien ne clignote à
+ * l'hydratation.
+ *
+ * Il ne rend rien en dehors de sa fenêtre d'affichage, ce qui évite l'écueil
+ * habituel de ce genre de bloc : rester en ligne jusqu'en mars.
+ */
+export default function SeasonAnnouncement({
+    ctaLabel,
+    ctaHref,
+    className,
+}: SeasonAnnouncementProps) {
+    const announcement = selectVisibleAnnouncement(SEASON_ANNOUNCEMENT);
+    if (!announcement) return null;
+
+    return (
+        <aside
+            aria-label='Annonce de rentrée'
+            className={cn(
+                'w-full max-w-md md:max-w-xl rounded-md border border-white/10 border-l-4 border-l-jkdBlueLight',
+                'bg-black/60 px-5 py-4 shadow-lg shadow-black/50 backdrop-blur-md',
+                className
+            )}
+        >
+            <p className='font-cinzel text-sm md:text-3xl font-bold uppercase tracking-[0.18em] md:tracking-[0.08em] text-jkdBlueLight drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)] whitespace-nowrap'>
+                {announcement.eyebrow}
+            </p>
+            <p className='mt-2 md:mt-3 text-sm leading-snug text-white md:text-lg'>
+                {announcement.message}
+            </p>
+            {announcement.detail ? (
+                <p className='mt-1.5 text-xs leading-snug text-gray-400 md:text-sm'>
+                    {announcement.detail}
+                </p>
+            ) : null}
+            <TransitionLink
+                href={ctaHref}
+                className='group mt-3 inline-flex items-center gap-1.5 text-sm text-white underline decoration-jkdBlueLight decoration-2 underline-offset-4 transition-colors hover:text-jkdBlueLight'
+            >
+                {ctaLabel}
+                <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-0.5' />
+            </TransitionLink>
+        </aside>
+    );
+}

--- a/components/ui/gradual-spacing.test.tsx
+++ b/components/ui/gradual-spacing.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import GradualSpacing from './gradual-spacing';
+
+/**
+ * Ces tests portent sur le HTML rendu par le serveur, pas sur l'arbre React.
+ * C'est exactement ce que voient Googlebot et les robots des moteurs de réponse
+ * (GPTBot, ClaudeBot, PerplexityBot), qui n'exécutent pas JavaScript.
+ */
+
+const countTag = (html: string, tag: string) =>
+    (html.match(new RegExp(`<${tag}[\\s>]`, 'g')) ?? []).length;
+
+describe('GradualSpacing', () => {
+    it("n'émet aucun titre par défaut", () => {
+        const html = renderToStaticMarkup(
+            <GradualSpacing text='Jeet Kune Do' />
+        );
+
+        expect(countTag(html, 'h1')).toBe(0);
+        expect(countTag(html, 'h2')).toBe(0);
+    });
+
+    it('émet exactement un titre quand un niveau est demandé', () => {
+        const html = renderToStaticMarkup(
+            <GradualSpacing as='h1' text='Les cours' />
+        );
+
+        expect(countTag(html, 'h1')).toBe(1);
+    });
+
+    it('ne crée jamais un titre par caractère', () => {
+        const text = 'Jeet Kune Do, Kali, Silat, Self-défense';
+        const html = renderToStaticMarkup(
+            <GradualSpacing as='h2' text={text} />
+        );
+
+        expect(countTag(html, 'h2')).toBe(1);
+        expect(countTag(html, 'h2')).not.toBe(text.length);
+    });
+
+    it('expose le texte complet, en un seul morceau, aux lecteurs sans JavaScript', () => {
+        const html = renderToStaticMarkup(
+            <GradualSpacing as='h1' text='Tarifs et horaires' />
+        );
+
+        expect(html).toContain('Tarifs et horaires');
+    });
+
+    it('masque les caractères animés aux technologies d’assistance', () => {
+        const text = 'Contact';
+        const html = renderToStaticMarkup(<GradualSpacing text={text} />);
+
+        // Un caractère masqué par lettre, plus rien de lisible en double
+        expect((html.match(/aria-hidden="true"/g) ?? []).length).toBe(
+            text.length
+        );
+    });
+
+    it('conserve les classes de style sur chaque caractère animé', () => {
+        const html = renderToStaticMarkup(
+            <GradualSpacing text='Ok' className='font-cinzel text-3xl' />
+        );
+
+        expect((html.match(/font-cinzel text-3xl/g) ?? []).length).toBe(2);
+    });
+});

--- a/components/ui/gradual-spacing.tsx
+++ b/components/ui/gradual-spacing.tsx
@@ -3,17 +3,30 @@
 import { cn } from '@/lib/utils';
 import { AnimatePresence, Variants, motion } from 'framer-motion';
 
+/**
+ * Éléments sémantiques autorisés pour le conteneur.
+ * Le défaut est `span` : une animation de texte ne doit jamais produire un
+ * titre par accident. Chaque page déclare explicitement son propre niveau.
+ */
+type GradualSpacingTag = 'span' | 'p' | 'h1' | 'h2' | 'h3';
+
 interface GradualSpacingProps {
     text: string;
+    /** Élément du conteneur. `span` par défaut, donc aucun titre. */
+    as?: GradualSpacingTag;
     duration?: number;
     delayMultiple?: number;
     framerProps?: Variants;
+    /** Classes appliquées à chaque caractère animé (taille, police, couleur). */
     className?: string;
+    /** Classes du conteneur, pour reproduire une mise en page existante. */
+    containerClassName?: string;
     onAnimationComplete?: () => void;
 }
 
 export default function GradualSpacing({
     text,
+    as: Tag = 'span',
     duration = 0.5,
     delayMultiple = 0.04,
     framerProps = {
@@ -21,14 +34,22 @@ export default function GradualSpacing({
         visible: { opacity: 1, x: 0 },
     },
     className,
+    containerClassName,
     onAnimationComplete,
 }: GradualSpacingProps) {
     return (
-        <div className='flex max-md:justify-center'>
+        <Tag className={cn('flex max-md:justify-center', containerClassName)}>
+            {/*
+                Le texte entier, en un seul nœud. C'est lui que lisent les
+                lecteurs d'écran et les robots qui n'exécutent pas JavaScript.
+                `sr-only` le sort du flux, la mise en page ne bouge pas.
+            */}
+            <span className='sr-only'>{text}</span>
             <AnimatePresence>
                 {text.split('').map((char, i) => (
-                    <motion.h1
+                    <motion.span
                         key={i}
+                        aria-hidden='true'
                         initial='hidden'
                         animate='visible'
                         exit='hidden'
@@ -42,9 +63,9 @@ export default function GradualSpacing({
                         }
                     >
                         {char === ' ' ? <span>&nbsp;</span> : char}
-                    </motion.h1>
+                    </motion.span>
                 ))}
             </AnimatePresence>
-        </div>
+        </Tag>
     );
 }

--- a/constant/announcement.ts
+++ b/constant/announcement.ts
@@ -1,0 +1,33 @@
+/**
+ * Annonce de saison affichée sur l'accueil et sur la page tarifs.
+ *
+ * Version codée en dur, volontairement. La forme des champs reproduit le futur
+ * document Sanity `annonce` pour que le passage au CMS ne soit qu'un changement
+ * de source : `lib/announcement.ts` et le composant n'auront pas à bouger.
+ *
+ * Pour modifier l'annonce aujourd'hui, éditer ce fichier et déployer.
+ * Les pages concernées se revalident toutes les heures, la fenêtre d'affichage
+ * prend donc effet sans redéploiement une fois les dates passées.
+ */
+export type Announcement = {
+    /** Surtitre court, en petites capitales. */
+    eyebrow: string;
+    /** L'information principale, une phrase. */
+    message: string;
+    /** Complément facultatif, une phrase. */
+    detail?: string;
+    /** Premier jour d'affichage, format `AAAA-MM-JJ`. */
+    visibleFrom: string;
+    /** Dernier jour d'affichage inclus, format `AAAA-MM-JJ`. */
+    visibleUntil: string;
+};
+
+export const SEASON_ANNOUNCEMENT: Announcement = {
+    eyebrow: 'Rentrée 2026 · 2027',
+    // Date confirmée par Yann le 30 août 2026.
+    message:
+        'Reprise des cours le mardi 8 septembre à 20h au Gymnase Albert Camus, à Muret.',
+    detail: 'Venez nous rencontrer au Forum des associations, dimanche 6 septembre de 10h à 17h à la Salle Horizon Pyrénées.',
+    visibleFrom: '2026-08-25',
+    visibleUntil: '2026-10-04',
+};

--- a/constant/config.ts
+++ b/constant/config.ts
@@ -16,7 +16,13 @@ export const associationConfig = {
         country: 'FR',
     },
     phoneNumber: '+33 6 84 05 93 26',
-    email: 'president@jeetkunedo31.com',
+    /**
+     * Adresse publique unique de l'association. Elle alimente le JSON-LD
+     * `Organization`, la page contact, les mentions légales et les supports
+     * imprimés. Elle doit rester identique à celle de l'affiche et de la fiche
+     * Google Business.
+     */
+    email: 'contact@jkd-selfdefense31.fr',
     socialMedia: {
         facebook: 'https://www.facebook.com/jkd.jidao',
         instagram: 'https://www.instagram.com/jeetkunedo_muret/',

--- a/docs/reviews/2026-08-30-titres-metadonnees-annonce.md
+++ b/docs/reviews/2026-08-30-titres-metadonnees-annonce.md
@@ -1,0 +1,188 @@
+# Revue du 30 août 2026 : titres, métadonnées et annonce de rentrée
+
+> Note de traçabilité. Elle date ce qui a été constaté en production, ce qui a été
+> corrigé, et ce qui reste ouvert. À lire avant de toucher aux titres, aux
+> métadonnées de route ou à l'annonce de saison.
+
+## Constat de départ, mesuré en production le 30 août 2026
+
+Les fondations livrées le 23 août tiennent : `robots.txt`, `sitemap.xml`,
+canonicals, redirections `.com` et apex, JSON-LD `Organization` / `WebSite` /
+`SportsActivityLocation`. Le contenu textuel est bien rendu par le serveur, donc
+lisible par les robots des moteurs de réponse, qui n'exécutent pas JavaScript.
+
+La couche éditoriale, elle, ne tenait pas. Nombre de balises `<h1>` dans le HTML
+servi par la production, avant correctif :
+
+| Page | `<h1>` avant | `<h1>` après |
+|---|---:|---:|
+| `/` | 0, et 39 après hydratation | 1 |
+| `/tarifs` | 47 | 1 |
+| `/27-styles` | 60 | 1 |
+| `/contact` | 14 | 1 |
+| `/events` | 10 | 1 |
+| `/association` | 1 | 1 |
+
+Cause : `GradualSpacing` animait le texte lettre par lettre en enveloppant
+**chaque caractère dans son propre `motion.h1`**. Le menu global en ajoutait 39 de
+plus après hydratation, un par lettre de « Jeet Kune Do, Kali, Silat,
+Self-défense », à l'intérieur d'un lien. Un lecteur d'écran épelait le titre.
+
+Deux autres défauts confirmés : la description de `/tarifs` reprenait mot pour mot
+celle de `/association`, et aucun titre de page ne contenait « Muret ».
+
+## Décisions
+
+| Décision | Choix | Pourquoi |
+|---|---|---|
+| Niveau de titre de `GradualSpacing` | Prop `as`, valeur par défaut `span` | Un composant d'animation ne doit pas décider de la sémantique. Le défaut ne produit aucun titre, chaque page déclare le sien. |
+| Texte accessible | `span.sr-only` avec le texte entier, caractères animés en `aria-hidden` | Plus robuste qu'un `aria-label` sur le conteneur, et le texte reste dans le HTML servi. |
+| Outil de test des composants | `renderToStaticMarkup` de `react-dom/server`, dans Vitest en environnement `node` | Le plan prévoyait `@testing-library` et `jsdom`. Trois dépendances de moins, et surtout on teste le HTML réellement servi, qui est précisément l'objet du défaut. |
+| Titre de l'accueil | `h1` en `sr-only` | Le héros est un logo sans texte. Le rendre visible demanderait de redessiner le héros, ce qui n'était pas le périmètre. |
+| Suffixe de marque | `title.template` sur le layout racine | Les titres de route se raccourcissent, et les fiches événement de Sanity gagnent le nom du club sans code supplémentaire. |
+| Adresse de contact | `contact@jkd-selfdefense31.fr` | Tranché par Yann. L'ancienne adresse divergeait de l'affiche et alimentait le JSON-LD. |
+| Couleur du surtitre de l'annonce | `jkdBlueLight` | Passé en rouge le temps d'un aller-retour, ramené au bleu par Yann. La taille doublée sur desktop (14 px → 30 px) est conservée. |
+| Forme de l'annonce de rentrée | Carte dans le héros de l'accueil, pas un bandeau | Le bas du héros est vide par construction, y compris sur mobile. Positionnée en absolu, elle ne décale aucun bloc existant. |
+| Source de l'annonce | Constante `constant/announcement.ts` | Codée en dur pour la version 1, décision de Yann. La forme des champs reproduit le futur document Sanity `annonce` pour que le passage au CMS ne change que la source. |
+
+## Changements de code
+
+- `components/ui/gradual-spacing.tsx` : prop `as` (`span` par défaut),
+  `containerClassName`, texte complet en `sr-only`, caractères en
+  `motion.span[aria-hidden]`.
+- `components/ui/gradual-spacing.test.tsx` : six tests sur le HTML serveur.
+- `vitest.config.ts` : `components/**/*.test.tsx` ajouté à `include`.
+- Niveaux déclarés sur les sept routes. `/27-styles` enveloppe ses deux à quatre
+  fragments animés dans un seul `h1` qui reprend la mise en page du `header`.
+- `app/(client)/page.tsx` : `h1` en `sr-only`, annonce de rentrée, `revalidate`.
+- `components/shared/menu.tsx` : plus aucun titre dans la navigation. Nom
+  accessible construit à partir du texte visible, qui diffère entre desktop et
+  mobile, d'où le champ `hint` en remplacement de `ariaLabel`. Cible tactile
+  portée à 44 px de haut sur mobile.
+- Métadonnées des sept routes : titre unique, description propre, Open Graph et
+  Twitter alignés. `title.template` sur le layout racine.
+- `constant/config.ts`, `emails/confirmation-email.tsx`, `README.md` : adresse de
+  contact unique. Le gabarit d'email dupliquait les coordonnées, il lit
+  désormais `associationConfig`.
+- `sanity/lib/imageUrl.ts` et ses six appels : l'objet image complet est passé au
+  constructeur d'URL au lieu de la seule référence d'asset. Le hotspot saisi dans
+  le Studio était jusqu'ici ignoré, et tout format fixe recadrait au centre.
+- `constant/announcement.ts`, `lib/announcement.ts` (+ 8 tests),
+  `components/shared/season-announcement.tsx`.
+- `tailwind.config.ts` : `jkdBlueLight` (`#4DA6D9`). `jkdBlue` sur fond sombre
+  plafonne à 2,4:1, sous le minimum de 4,5:1 exigé pour du petit texte. `jkdRed`
+  et `jkdRedLight` ajoutés au passage, non utilisés par l'annonce après retour
+  au bleu, mais ils documentent le rouge du logo déjà présent dans
+  `event-origin-badge.tsx`.
+- `components/shared/avatar-personality.tsx` : ne rend plus rien quand aucun nom
+  n'est connu. Les valeurs par défaut `N/A` et `Unknown Title` s'affichaient
+  telles quelles sur les événements sans personnalité saisie dans le Studio.
+  Six tests unitaires, plus un test Playwright qui balaie `/events` et chaque
+  fiche.
+
+## Vérification de non-régression visuelle
+
+Exigence de Yann : les visuels en place ne doivent pas bouger. Vérifié en
+comparant le build de production local à la production, qui servait encore
+l'ancien code, à viewport identique.
+
+| Page | Hauteur de page, production | Hauteur de page, local | Repères de mise en page |
+|---|---:|---:|---|
+| `/` | 3722 px | 3722 px | identiques |
+| `/tarifs` | 4115 px | 4115 px | 8 blocs, mêmes `top` et `height` au pixel |
+| `/27-styles` | 3411 px | 3411 px | `header` à 40 px, hauteur 200 px |
+| `/contact` | 2342 px | 2342 px | identiques |
+
+Aucun décalage. Les seuls écarts visuels sont l'annonce de rentrée, qui est du
+contenu nouveau et volontaire.
+
+Défaut trouvé et corrigé pendant cette vérification : sur mobile, le bouton
+flottant « Notre démo » est en `fixed bottom-24 right-4` et reste affiché en
+permanence. L'annonce, placée au même niveau, le chevauchait. Elle est remontée
+à `bottom-40`.
+
+## Incident : le site basculait en thème clair
+
+Symptôme signalé par Yann : bandeau de navigation blanc sur `localhost:3000`.
+
+**Première hypothèse, fausse.** J'ai accusé une corruption de `.next`, au motif
+qu'un `pnpm dev` tournait pendant que je lançais `pnpm build`. C'était une
+explication plausible affirmée sans mesure. Un `rm -rf .next` a semblé la
+confirmer parce que le serveur redémarré était lu par Playwright dans un contexte
+neuf, donc sans `localStorage`.
+
+**Cause réelle, mesurée.** Diagnostic Playwright croisant préférence système et
+valeur stockée, sur `/` :
+
+| Système | `localStorage.theme` | classe sur `<html>` | fond du bandeau |
+|---|---|---|---|
+| dark | absent | `dark` | `rgb(24, 24, 27)` |
+| light | absent | `dark` | `rgb(24, 24, 27)` |
+| light | `system` | **`light`** | **`rgb(250, 250, 250)`** |
+| dark | `system` | `dark` | `rgb(24, 24, 27)` |
+| light | `light` | **`light`** | **`rgb(250, 250, 250)`** |
+
+`next-themes` était configuré en `defaultTheme='dark'` avec `enableSystem`. Une clé
+`theme` déjà présente dans `localStorage` gagne sur le thème par défaut. Sur
+`localhost:3000`, cette clé est partagée par tous les projets servis sur ce port,
+et `components/ui/mode-toggle.tsx` n'est rendu nulle part : personne ne pouvait
+revenir en arrière depuis l'interface.
+
+Le symptôme se voit d'abord sur la navigation parce que `AuroraBackground` est en
+`bg-zinc-50 dark:bg-zinc-900` avec `invert dark:invert-0`.
+
+**Correctif :** `forcedTheme='dark'`. Le site est conçu en sombre uniquement, il
+n'a pas de sélecteur de thème, `enableSystem` n'apportait donc qu'un risque.
+
+Défaut de méthode à retenir : la première version de `e2e/rendu.spec.ts` posait
+`colorScheme: 'dark'` dans la configuration Playwright. Le test ne pouvait pas
+échouer. La configuration est passée en `colorScheme: 'light'`, et la
+non-régression a été vérifiée en réintroduisant temporairement `enableSystem` :
+les deux tests concernés échouent bien sans le correctif.
+
+## Vérification par Playwright
+
+`@playwright/test` ajouté, avec `channel: 'chrome'` pour utiliser le Chrome de la
+machine sans télécharger de binaire. `e2e/rendu.spec.ts` vérifie sur les sept
+routes publiques et deux profils d'appareil : aucune feuille de style en erreur,
+classe `dark` sur `<html>`, fond de page et bandeau de navigation effectivement
+sombres, un seul `h1`. Deux tests supplémentaires posent `localStorage.theme` à
+`system` puis `light` et exigent que le site reste sombre. Un dernier mesure les
+boîtes de l'annonce et du bouton flottant pour prouver qu'elles sont disjointes.
+
+`e2e/diagnostic-theme.spec.ts` reste comme outil de diagnostic, il n'assertionne
+rien.
+
+`pnpm test:e2e` : 34 tests, 34 au vert.
+
+Note d'exploitation : `next dev` et `next build` partagent `.next`. Éviter de les
+lancer en parallèle reste une bonne pratique, mais ce n'était pas la cause ici.
+
+## Chaîne qualité
+
+`pnpm lint` 0 erreur et 8 avertissements préexistants (lot 3), `tsc --noEmit`
+propre, `pnpm test` 36/36, `pnpm build` réussi. `/` et `/tarifs` passent de
+statiques à revalidées toutes les heures, sans quoi la fenêtre d'affichage de
+l'annonce resterait figée à l'heure du build.
+
+## Ouvert
+
+- [x] Date de reprise confirmée par Yann le 30 août 2026 : mardi 8 septembre à
+      20h. Le cours ado de 18h30 n'est volontairement pas mentionné, décision de
+      Yann.
+- [ ] Créer la boîte `contact@jkd-selfdefense31.fr` et faire suivre l'ancienne.
+      Le site l'affiche désormais partout.
+- [ ] Trancher la page Facebook : l'affiche renvoie vers « Jeet Kune Do
+      Toulouse », le site vers `facebook.com/jkd.jidao`.
+- [ ] Sortir les cinq événements externes du sitemap : leur canonical pointe vers
+      un autre domaine.
+- [ ] Champ `organisateur` optionnel dans le schéma événement, pour ne pas
+      déclarer le club organisateur d'un forum municipal.
+- [ ] Relancer Lighthouse accessibilité mobile et viser 100.
+- [ ] Remplacer l'imbrication `<button><a>` de `contact-button.tsx`, seul point
+      de la tâche 3 non traité.
+- [ ] Passer l'annonce dans Sanity quand la version codée en dur aura fait ses
+      preuves.
+
+Contexte et arbitrages : [`../seo/plans/2026-08-30-rentree-2026-annonce-et-forum.md`](../seo/plans/2026-08-30-rentree-2026-annonce-et-forum.md).
+Fiche à saisir : [`../seo/deliverables/2026-09-06-forum-associations-sanity.md`](../seo/deliverables/2026-09-06-forum-associations-sanity.md).

--- a/docs/seo/deliverables/2026-09-06-forum-associations-sanity.md
+++ b/docs/seo/deliverables/2026-09-06-forum-associations-sanity.md
@@ -1,0 +1,89 @@
+# Fiche Sanity : Forum des associations de Muret 2026
+
+À saisir dans le Studio, document **Événement**. Prêt à publier : la date de
+reprise a été confirmée par Yann le 30 août 2026.
+
+## Champs
+
+| Champ du Studio | Valeur à saisir |
+|---|---|
+| **Titre** | `Forum des associations de Muret 2026` |
+| **Slug** | `forum-des-associations-muret-2026` |
+| **Origine** | Interne |
+| **Dates de l'événement** | `06/09/2026` |
+| **Tranches horaires** | `10h - 17h` |
+| **Lieu, nom** | `Salle Horizon Pyrénées` |
+| **Lieu, adresse** | `253 avenue des Pyrénées` |
+| **Lieu, code postal** | `31600` |
+| **Lieu, ville** | `Muret` |
+| **Personnalité** | laisser vide |
+| **Image principale** | l'affiche du forum |
+
+Le lieu est pré-rempli avec le Gymnase Albert Camus à la création : il faut le
+remplacer par la Salle Horizon Pyrénées.
+
+## Descriptif
+
+Texte simple. Un double saut de ligne crée un paragraphe, un saut simple crée un
+retour à la ligne. Ni gras ni puces, le champ ne les interprète pas.
+
+```
+Le club JKD Self Defense 31 tient un stand au Forum des associations de Muret, le dimanche 6 septembre 2026 de 10h à 17h à la Salle Horizon Pyrénées. Entrée libre et gratuite, parking gratuit.
+
+Les instructeurs du club sont présents toute la journée. Quel cours choisir, à partir de quel âge, quel niveau physique faut-il, comment se passe un premier cours : venez poser vos questions, sans rendez-vous et sans engagement.
+
+Ce que nous enseignons
+Le Jeet Kune Do, l'art martial créé par Bruce Lee, ainsi que le Kali philippin, le Silat et le JKD Boxing (Jun Fan Kick Boxing). Le club propose aussi de la self-défense féminine, de la self-défense mixte et un cours ados de 13 à 15 ans.
+
+Nos cours à Muret
+Les entraînements ont lieu au Gymnase Albert Camus, 6 rue Pierre Bauduc à Muret, les mardis, mercredis et jeudis en soirée. La reprise de la saison 2026-2027 a lieu le mardi 8 septembre 2026 à 20h.
+
+Venir essayer
+Si vous ne pouvez pas passer au forum, écrivez-nous depuis la page contact du site ou appelez le 06 84 05 93 26. Nous répondons à toutes les demandes, y compris celles de personnes qui n'ont jamais pratiqué.
+```
+
+La première phrase est reprise telle quelle comme description dans les résultats
+Google, parce que le code envoie le descriptif entier dans la balise. Elle
+contient donc à elle seule la discipline, la ville, la date, l'heure, le lieu et
+la gratuité. Ne pas la raccourcir.
+
+## Le recadrage de l'image, en pratique
+
+Ce n'est ni du Next.js ni un travail manuel dans un éditeur d'images. C'est le
+**hotspot de Sanity**, et il se règle en trois clics dans le Studio :
+
+1. téléverser l'affiche dans **Image principale** ;
+2. cliquer sur l'image, puis sur l'icône de recadrage qui apparaît ;
+3. déplacer le cercle du hotspot sur la photo des instructeurs, en haut de
+   l'affiche, et valider.
+
+Le site demande ensuite une image en 1200 × 630 pour l'aperçu Facebook et
+LinkedIn. Sanity recadre autour du hotspot au lieu de couper au centre, donc
+l'aperçu montre les instructeurs et non le milieu du texte.
+
+Le code jetait cette information : il passait la seule référence de l'asset
+(`mainImage.asset._ref`) au constructeur d'URL, alors que le hotspot vit sur
+l'objet image complet. Corrigé le 30 août 2026 dans `sanity/lib/imageUrl.ts` et
+les six appels concernés. Sans ce correctif, régler le hotspot n'aurait rien
+changé à l'aperçu.
+
+Le texte de l'affiche reste invisible pour Google et pour les moteurs de réponse,
+puisque c'est une image. Tout ce qui doit être trouvé en recherche doit figurer
+dans le descriptif ci-dessus.
+
+## Pourquoi « Interne » et non « Externe »
+
+Le champ ne dit pas qui organise, il dit à qui appartient la page. En externe, la
+canonical part vers le site d'origine et la fiche n'est plus indexée pour
+elle-même. Or l'objectif est justement de sortir sur « forum des associations
+Muret arts martiaux ».
+
+Réserve assumée : en interne, les données structurées déclarent
+`organizer: JKD Self Defense 31`. Le forum est organisé par la mairie de Muret,
+nous y tenons un stand. Un champ `organisateur` optionnel dans le schéma corrigera
+ce point, c'est une modification de quinze minutes inscrite au backlog.
+
+## Sources
+
+- [Salle événementielle Horizon Pyrénées, mairie de Muret](https://www.mairie-muret.fr/vie-economique-ville-de-muret/salle-evenementielle-horizon-pyrenees)
+- [Forum des associations, agenda de la mairie de Muret](https://www.mairie-muret.fr/muret-bouge/evenements-agenda-ville-de-muret/588-forum-des-associations)

--- a/docs/seo/plans/2026-08-30-rentree-2026-annonce-et-forum.md
+++ b/docs/seo/plans/2026-08-30-rentree-2026-annonce-et-forum.md
@@ -1,0 +1,227 @@
+# Rentrée 2026-2027 : annonce sur le site et fiche Forum des associations
+
+> Note de travail du 30 août 2026. Trois sujets : ce que vaut réellement le site après
+> les correctifs SEO d'août, le contenu à saisir dans le Studio Sanity pour le Forum des
+> associations, et la forme que doit prendre l'annonce de rentrée.
+
+## 1. Vérification SEO et robots IA, faite en production
+
+Toutes les vérifications ci-dessous ont été faites le 30 août 2026 sur
+`https://www.jkd-selfdefense31.fr`, pas sur le code local. `develop` et `main` sont au
+même commit, la production contient donc bien le lot 1 de la revue du 23 août.
+
+### Ce qui est bon
+
+| Contrôle | Résultat |
+|---|---|
+| `robots.txt` | 200, `Allow: /`, `Disallow: /studio/`, `Host` et `Sitemap` corrects |
+| `sitemap.xml` | 13 URLs, toutes en `.fr`, aucune preview Vercel, aucun `/studio` |
+| Redirection `jkd-selfdefense31.fr` sans www | 308 vers `www` |
+| Redirection `.com` | 308 vers `www.jkd-selfdefense31.fr` |
+| Canonical page d'accueil | `https://www.jkd-selfdefense31.fr/` |
+| JSON-LD global | `Organization`, `WebSite`, `SportsActivityLocation` présents dans le HTML serveur |
+| Contenu lisible sans JavaScript | oui, le texte des pages est dans le HTML rendu par le serveur |
+| Chaîne qualité locale | `pnpm test` 22/22, aucun `.com` ni `VERCEL_PROJECT_PRODUCTION_URL` dans les URLs publiques |
+
+Le dernier point est celui qui compte le plus pour les robots IA. GPTBot, ClaudeBot et
+PerplexityBot n'exécutent pas JavaScript. Un site dont le contenu n'apparaît qu'après
+hydratation leur est invisible. Ici le texte est bien servi par le serveur, et `robots.txt`
+ne bloque aucun de ces agents.
+
+### Ce qui ne va pas, vérifié page par page
+
+Nombre de balises `<h1>` dans le HTML servi par le serveur :
+
+| Page | `<h1>` | Attendu |
+|---|---:|---:|
+| `/` | **0** | 1 |
+| `/tarifs` | **47** | 1 |
+| `/27-styles` | **60** | 1 |
+| `/contact` | **14** | 1 |
+| `/events` | **10** | 1 |
+| `/association` | 1 | 1 |
+
+Le composant `GradualSpacing` anime le titre lettre par lettre et enveloppe **chaque
+caractère dans son propre `<h1>`**. Sur l'accueil, l'animation est cliente : le serveur
+n'envoie aucun `<h1>`, et après hydratation le navigateur en compte 39, un par lettre de
+« Jeet Kune Do ». Un robot voit donc soit rien, soit du bruit. C'est la tâche 3 du plan
+technique, jamais commencée, et c'est aujourd'hui le défaut le plus coûteux du site.
+
+Trois autres écarts confirmés :
+
+| Écart | Détail | Conséquence |
+|---|---|---|
+| Titres et descriptions non travaillés | Accueil : `Jeet Kune Do Toulouse - Arts Martiaux et Self-Défense`. Le mot Muret n'y est pas, alors que c'est la ville du club. `/tarifs` porte la description de `/association`, mot pour mot. | Tâche 4 du plan. Perte directe de clics sur les requêtes locales. |
+| Événements externes dans le sitemap | `/events/17d4b558…` est listé dans le sitemap mais sa canonical pointe vers `https://www.ecole-delannoy.fr`. Cinq fiches sont dans ce cas. | Signal contradictoire envoyé à Google. Il faut soit les sortir du sitemap, soit les passer en `noindex`. |
+| Pas de suffixe de marque sur les fiches événement | Le layout n'a pas de `title.template`, donc l'onglet affiche seulement le titre saisi dans Sanity. | Le nom du club disparaît des résultats de recherche sur ces pages. |
+
+### Deux détails de cohérence à trancher
+
+- L'affiche du forum donne `contact@jkd-selfdefense31.fr`, alors que `constant/config.ts`
+  déclare `president@jeetkunedo31.com`. Cette adresse alimente le JSON-LD `Organization`
+  et la page mentions légales. Il faut une seule adresse publique.
+- L'affiche renvoie vers la page Facebook « Jeet Kune Do Toulouse », le site vers
+  `facebook.com/jkd.jidao`. Même problème, il faut une seule page.
+
+## 2. Fiche Sanity du Forum des associations
+
+### Choix retenu : origine « Interne »
+
+Le champ `origine` ne décrit pas qui organise, il décrit **à qui appartient la page**.
+Un événement externe reçoit une canonical vers le site d'origine, donc la fiche n'est
+pas indexée pour elle-même. Or on veut précisément que quelqu'un qui cherche
+« forum des associations Muret arts martiaux » tombe sur nous. Le forum est donc saisi
+en interne, avec le lieu remplacé.
+
+Réserve à noter : en interne, le JSON-LD déclare `organizer: JKD Self Defense 31`. Le
+forum est organisé par la mairie de Muret, nous y tenons un stand. C'est inexact.
+Correctif de quinze minutes proposé en partie 4.
+
+### Champs à saisir
+
+| Champ du Studio | Valeur |
+|---|---|
+| Titre | `Forum des associations de Muret 2026` |
+| Slug | `forum-des-associations-muret-2026` |
+| Origine | Interne |
+| Dates de l'événement | `2026-09-06` |
+| Tranches horaires | `10h - 17h` |
+| Lieu, nom | `Salle Horizon Pyrénées` |
+| Lieu, adresse | `253 avenue des Pyrénées` |
+| Lieu, code postal | `31600` |
+| Lieu, ville | `Muret` |
+| Personnalité | laisser vide |
+| Image principale | l'affiche, avec le point de recadrage placé sur la photo des instructeurs |
+
+Le lieu et l'horaire sont confirmés par la mairie de Muret et par la fiche du site
+municipal. Ne pas les saisir de mémoire.
+
+**Le point de recadrage compte.** L'aperçu Facebook et l'image Open Graph sont générés en
+1200 × 630 à partir de cette image. Une affiche verticale recadrée au centre donnera un
+bandeau illisible. Placer le hotspot sur le groupe d'instructeurs en haut de l'affiche.
+
+**Le texte de l'affiche n'est lisible ni par Google ni par une IA.** C'est une image. Tout
+ce qui doit être trouvé en recherche doit figurer dans le descriptif ci-dessous.
+
+### Descriptif à coller
+
+Le champ accepte du texte simple. Les doubles sauts de ligne créent des paragraphes, les
+simples sauts de ligne créent des retours à la ligne. Pas de gras ni de listes à puces.
+
+```text
+Le club JKD Self Defense 31 tient un stand au Forum des associations de Muret, le dimanche 6 septembre 2026 de 10h à 17h à la Salle Horizon Pyrénées. Entrée libre et gratuite, parking gratuit.
+
+Les instructeurs du club sont présents toute la journée. Quel cours choisir, à partir de quel âge, quel niveau physique faut-il, comment se passe un premier cours : venez poser vos questions, sans rendez-vous et sans engagement.
+
+Ce que nous enseignons
+Le Jeet Kune Do, l'art martial créé par Bruce Lee, ainsi que le Kali philippin, le Silat et le JKD Boxing (Jun Fan Kick Boxing). Le club propose aussi de la self-défense féminine, de la self-défense mixte et un cours ados de 13 à 15 ans.
+
+Nos cours à Muret
+Les entraînements ont lieu au Gymnase Albert Camus, 6 rue Pierre Bauduc à Muret, les mardis, mercredis et jeudis en soirée. La reprise de la saison 2026-2027 a lieu le RENTREE_A_CONFIRMER.
+
+Venir essayer
+Si vous ne pouvez pas passer au forum, écrivez-nous depuis la page contact du site ou appelez le 06 84 05 93 26. Nous répondons à toutes les demandes, y compris celles de personnes qui n'ont jamais pratiqué.
+```
+
+Remplacer `RENTREE_A_CONFIRMER` par la date réelle avant publication.
+
+La première phrase est celle qui sera reprise comme meta description par Google, parce
+que le code envoie le descriptif entier dans la balise. Elle a donc été écrite pour tenir
+seule : discipline, ville, date, heure, lieu, gratuité.
+
+## 3. L'annonce de rentrée : forme et emplacement
+
+### Recommandation
+
+**Un bandeau d'annonce affiché sur toutes les pages, piloté depuis Sanity, avec une
+fenêtre d'affichage.**
+
+Trois raisons de trancher ainsi plutôt que de poser un encart sur l'accueil :
+
+1. La question « quand est-ce que ça reprend » se pose sur n'importe quelle page.
+   Aujourd'hui `/tarifs` est la deuxième page la plus consultée, et quelqu'un qui arrive
+   dessus depuis Google ne verra jamais un encart posé sur l'accueil.
+2. Piloté depuis Sanity, le texte se change sans déploiement. C'est ce qui fait la
+   différence entre une annonce utilisée et une annonce oubliée.
+3. Une fenêtre d'affichage (`visible du` / `visible jusqu'au`) fait disparaître le
+   bandeau tout seul. C'est ce qui tue la plupart des bandeaux d'annonce : ils restent
+   affichés jusqu'en mars.
+
+Pas de bouton pour fermer le bandeau en version 1. Une pièce mobile de moins, et il
+expire de lui-même.
+
+### Emplacement exact
+
+Tout en haut du contenu, avant le titre de page. Sur mobile la barre de navigation est
+en bas de l'écran, le haut est donc libre. Sur desktop la barre est fixe en haut, le
+bandeau se place juste en dessous et défile avec la page.
+
+### Texte du bandeau
+
+```text
+Rentrée le RENTREE_A_CONFIRMER au Gymnase Albert Camus. Rencontrez-nous au Forum des associations le dimanche 6 septembre.
+```
+
+Lien : `Horaires, tarifs et premier cours` vers `/tarifs`.
+
+### Spécification technique
+
+Nouveau document Sanity `annonce`, en singleton.
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `message` | `text` | le texte du bandeau, une à deux phrases |
+| `ctaLabel` | `string` | libellé du lien, décrit la destination |
+| `ctaHref` | `string` | chemin interne du site |
+| `visibleFrom` | `datetime` | début d'affichage |
+| `visibleUntil` | `datetime` | fin d'affichage, obligatoire |
+
+Rendu côté serveur dans `app/(client)/layout.tsx`, au-dessus de `{children}`. La fenêtre
+d'affichage se calcule dans une fonction pure de `lib/`, testée, conformément à la règle
+du projet qui interdit la logique métier dans les composants. Revalidation à l'heure,
+comme le sitemap.
+
+Charge estimée : une demi-journée, tests compris.
+
+### Les deux autres emplacements, dans le même chantier
+
+- **Un bloc rentrée en haut de `/tarifs`** : date de reprise, ce qu'il faut apporter au
+  premier cours, comment demander un essai. C'est la page où la décision se prend, et
+  elle contient déjà les horaires.
+- **La fiche événement du forum** sert de page d'atterrissage pour ceux qui arrivent de
+  Facebook ou de l'affiche. C'est la partie 2 de cette note.
+
+Une même grille : on met l'information là où la question se pose.
+
+### Ce qu'il manque pour publier
+
+Quatre informations que je ne peux pas inventer :
+
+1. la date exacte de reprise des cours ;
+2. le premier cours d'essai est-il gratuit, et combien de séances d'essai sont offertes ;
+3. l'adresse email publique retenue, celle de l'affiche ou celle du code ;
+4. la page Facebook retenue.
+
+## 4. Ce qui reste à faire, par ordre de rendement
+
+| Priorité | Action | Charge | Pourquoi maintenant |
+|---|---|---|---|
+| P0 | Corriger `GradualSpacing` : un seul `<h1>` par page, caractères animés en `span[aria-hidden]` | 0,5 j | Tâche 3 du plan. 47 `<h1>` sur `/tarifs`, 0 sur l'accueil. Rien d'autre ne rattrape ça. |
+| P0 | Titres et descriptions par page, avec Muret | 0,5 j | Tâche 4. `/tarifs` porte la description de `/association`. |
+| P0 | Bandeau d'annonce Sanity | 0,5 j | Partie 3. La fenêtre de rentrée dure six semaines. |
+| P1 | Sortir les événements externes du sitemap | 1 h | Leur canonical pointe ailleurs, ils n'ont rien à y faire. |
+| P1 | `title.template` `%s \| JKD Self Defense 31` dans le layout | 15 min | Le nom du club manque sur les fiches événement. |
+| P1 | Champ `organizer` optionnel dans le schéma événement | 15 min | Ne pas déclarer le club organisateur d'un forum municipal. |
+| P1 | Page `/cours-essai` | 1 j | Page P0 de la stratégie de contenu, cible « cours d'essai arts martiaux Muret ». Le bandeau pointera dessus une fois publiée. |
+| P2 | Routage des fiches événement par slug au lieu de l'identifiant Sanity | 0,5 j | `/events/forum-des-associations-muret-2026` au lieu de `/events/076fddca-54ea-…`. Le champ `slug` existe déjà et n'est pas utilisé. Nécessite des redirections 308 depuis les anciennes URLs. |
+| P2 | Fusionner la tranche horaire dans `startDate` du JSON-LD | 1 h | `startDate` vaut aujourd'hui `2026-09-06` sans heure, alors que `timeSlots` contient `10h - 17h`. |
+| P2 | Meta description dédiée pour les événements | 1 h | Le descriptif entier part dans la balise, Google la tronque. |
+
+## Sources
+
+- [Salle événementielle Horizon Pyrénées, mairie de Muret](https://www.mairie-muret.fr/vie-economique-ville-de-muret/salle-evenementielle-horizon-pyrenees)
+- [Forum des associations, agenda de la mairie de Muret](https://www.mairie-muret.fr/muret-bouge/evenements-agenda-ville-de-muret/588-forum-des-associations)
+- [Salle Horizon, 253 avenue des Pyrénées, Muret](https://www.waze.com/live-map/directions/salle-horizon-avenue-des-pyrenees-253-muret?to=place.w.852402.8589560.24577972)
+- [`docs/seo/technical/implementation-plan.md`](../technical/implementation-plan.md), tâches 3, 4 et 8
+- [`docs/reviews/2026-08-23-revue-qualite.md`](../../reviews/2026-08-23-revue-qualite.md)
+- [`docs/seo/strategy/content-and-keywords.md`](../strategy/content-and-keywords.md), briefs `/cours-essai` et `/tarifs`

--- a/docs/seo/technical/implementation-plan.md
+++ b/docs/seo/technical/implementation-plan.md
@@ -82,6 +82,8 @@ export const SITE = {
 
 ### Task 3: Réparer la hiérarchie des titres et l'accessibilité du menu
 
+> **Réalisé le 30 août 2026.** Détail : [`../../reviews/2026-08-30-titres-metadonnees-annonce.md`](../../reviews/2026-08-30-titres-metadonnees-annonce.md). Écarts : le test vit dans `components/ui/gradual-spacing.test.tsx` et rend du HTML serveur avec `renderToStaticMarkup`, sans `@testing-library` ni `jsdom`. Lighthouse accessibilité non relancé.
+
 **Files:**
 - Modify: `components/ui/gradual-spacing.tsx`
 - Modify: `components/shared/menu.tsx`
@@ -89,18 +91,20 @@ export const SITE = {
 - Test: `tests/components/gradual-spacing.test.tsx`
 - Test: `tests/components/menu.test.tsx`
 
-- [ ] Ajouter `@testing-library/react`, `@testing-library/jest-dom` et `jsdom` si les tests DOM sont retenus.
-- [ ] Écrire un test qui rend `GradualSpacing` et exige un seul heading, jamais un heading par caractère.
-- [ ] Faire accepter au composant un élément sémantique (`span`, `p`, `h1`, `h2`) ; valeur par défaut `span`.
-- [ ] Garder les caractères animés dans des `span[aria-hidden=true]` et fournir le libellé complet au lecteur d'écran.
-- [ ] Dans le menu global, ne rendre aucun H1. Réserver un H1 unique au contenu principal de chaque page.
-- [ ] Corriger le lien événements : son nom accessible doit inclure le texte visible.
+- [x] ~~Ajouter `@testing-library/react`, `@testing-library/jest-dom` et `jsdom`~~ : non retenu. `renderToStaticMarkup` teste le HTML servi, c'est-à-dire exactement ce que voient les robots, sans nouvelle dépendance.
+- [x] Écrire un test qui rend `GradualSpacing` et exige un seul heading, jamais un heading par caractère.
+- [x] Faire accepter au composant un élément sémantique (`span`, `p`, `h1`, `h2`) ; valeur par défaut `span`.
+- [x] Garder les caractères animés dans des `span[aria-hidden=true]` et fournir le libellé complet au lecteur d'écran.
+- [x] Dans le menu global, ne rendre aucun H1. Réserver un H1 unique au contenu principal de chaque page.
+- [x] Corriger le lien événements : son nom accessible doit inclure le texte visible.
 - [ ] Remplacer l'imbrication `<button><a>` du CTA par un seul `Button asChild` contenant le lien.
-- [ ] Garantir une cible d'au moins 44 × 44 px et une indication de focus visible.
+- [x] Garantir une cible d'au moins 44 × 44 px et une indication de focus visible.
 - [ ] Exécuter les tests puis un Lighthouse accessibilité mobile ; objectif 100 sans `label-content-name-mismatch` ni `target-size`.
 - [ ] Commit proposé : `fix(a11y): restore semantic headings and menu controls`.
 
 ### Task 4: Renforcer les métadonnées éditoriales
+
+> **Réalisé le 30 août 2026.** Détail : [`../../reviews/2026-08-30-titres-metadonnees-annonce.md`](../../reviews/2026-08-30-titres-metadonnees-annonce.md). Ajout non prévu : `title.template` au niveau du layout racine, qui suffixe automatiquement les fiches événement.
 
 **Files:**
 - Modify: `app/(client)/layout.tsx`
@@ -111,12 +115,12 @@ export const SITE = {
 - Modify: `app/(client)/events/[eventId]/page.tsx`
 - Test: `tests/seo/metadata.test.ts`
 
-- [ ] Définir le titre d'accueil : `Jeet Kune Do & Self-défense à Muret | JKD 31`.
-- [ ] Rédiger pour chaque route un title unique, une description locale et un Open Graph cohérent.
-- [ ] Générer les métadonnées événement depuis Sanity avec titre, date, image, description et canonical stable.
+- [x] Définir le titre d'accueil : `Jeet Kune Do et self-défense à Muret | JKD Self Defense 31`.
+- [x] Rédiger pour chaque route un title unique, une description locale et un Open Graph cohérent.
+- [x] Générer les métadonnées événement depuis Sanity avec titre, date, image, description et canonical stable.
 - [ ] Ajouter des images alternatives descriptives ; éviter la répétition de mots-clés.
-- [ ] Tester unicité, longueur raisonnable et présence de `Muret` sur les pages d'intention locale.
-- [ ] Valider le HTML rendu, pas seulement les objets TypeScript.
+- [x] Tester unicité, longueur raisonnable et présence de `Muret` sur les pages d'intention locale.
+- [x] Valider le HTML rendu, pas seulement les objets TypeScript.
 - [ ] Commit proposé : `feat(seo): localize route metadata`.
 
 ### Task 5: Mesurer le parcours vers le cours d'essai

--- a/e2e/diagnostic-theme.spec.ts
+++ b/e2e/diagnostic-theme.spec.ts
@@ -1,0 +1,67 @@
+import { chromium, test } from '@playwright/test';
+
+/**
+ * Diagnostic, pas une garantie. Rapporte la classe posée sur `<html>` et la
+ * couleur réelle du bandeau de navigation selon deux variables : la préférence
+ * de couleur du système, et ce que `next-themes` a pu écrire dans
+ * `localStorage` lors d'une visite précédente.
+ *
+ * `pnpm exec playwright test e2e/diagnostic-theme.spec.ts --project=desktop`
+ */
+
+const CASES = [
+    { scheme: 'dark' as const, stored: null },
+    { scheme: 'light' as const, stored: null },
+    { scheme: 'light' as const, stored: 'system' },
+    { scheme: 'dark' as const, stored: 'system' },
+    { scheme: 'light' as const, stored: 'light' },
+];
+
+test('diagnostic du thème', async () => {
+    const browser = await chromium.launch({ channel: 'chrome' });
+    const rows: string[] = [];
+
+    for (const { scheme, stored } of CASES) {
+        const context = await browser.newContext({ colorScheme: scheme });
+        const page = await context.newPage();
+
+        if (stored) {
+            await page.addInitScript(
+                (value) => window.localStorage.setItem('theme', value),
+                stored
+            );
+        }
+
+        await page.goto('http://localhost:3000/');
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1200);
+
+        const state = await page.evaluate(() => {
+            const aurora = document.querySelector('nav div');
+            return {
+                htmlClass: document.documentElement.className,
+                stored: window.localStorage.getItem('theme'),
+                nav: aurora
+                    ? getComputedStyle(aurora).backgroundColor
+                    : 'introuvable',
+                body: getComputedStyle(document.body).backgroundColor,
+            };
+        });
+
+        rows.push(
+            [
+                `système=${scheme}`.padEnd(16),
+                `localStorage avant=${String(stored)}`.padEnd(28),
+                `class="${state.htmlClass}"`.padEnd(24),
+                `localStorage après=${state.stored}`.padEnd(26),
+                `nav=${state.nav}`.padEnd(28),
+                `body=${state.body}`,
+            ].join(' | ')
+        );
+
+        await context.close();
+    }
+
+    await browser.close();
+    console.log('\n' + rows.join('\n') + '\n');
+});

--- a/e2e/rendu.spec.ts
+++ b/e2e/rendu.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Ce que ces tests garantissent, et que les tests unitaires ne peuvent pas voir :
+ * le CSS est bien chargé, le thème sombre est appliqué, et chaque page publique
+ * porte un seul `h1`.
+ *
+ * Le thème sombre est imposé par `forcedTheme` dans `app/(client)/layout.tsx`.
+ * Une page qui remonte en fond blanc signifie soit que la classe `dark` n'est pas
+ * posée, soit que la feuille de style n'est pas servie.
+ */
+
+const PAGES = [
+    '/',
+    '/association',
+    '/tarifs',
+    '/events',
+    '/contact',
+    '/27-styles',
+    '/legal',
+];
+
+/** `rgb(2, 8, 23)` : `--background` du thème sombre. Le clair est blanc pur. */
+const isDarkBackground = (color: string): boolean => {
+    const parts = color.match(/\d+/g)?.slice(0, 3).map(Number);
+    if (!parts || parts.length < 3) return false;
+    return parts.every((channel) => channel < 60);
+};
+
+/**
+ * Attend la fin des animations d'entrée avant toute mesure.
+ *
+ * Pas de `networkidle` : Vercel Analytics et Speed Insights émettent des balises
+ * en continu, l'état n'arrive jamais de façon fiable.
+ */
+const settle = async (page: Page) => {
+    await page.waitForLoadState('load');
+    await page.waitForTimeout(1500);
+};
+
+test.describe('rendu des pages publiques', () => {
+    for (const path of PAGES) {
+        test(`${path} : CSS chargé et thème sombre appliqué`, async ({
+            page,
+        }) => {
+            const failed: string[] = [];
+            page.on('response', (response) => {
+                if (response.url().endsWith('.css') && response.status() >= 400) {
+                    failed.push(`${response.status()} ${response.url()}`);
+                }
+            });
+
+            await page.goto(path);
+            await settle(page);
+
+            expect(failed, 'aucune feuille de style en erreur').toEqual([]);
+
+            const stylesheets = await page.evaluate(
+                () => document.styleSheets.length
+            );
+            expect(stylesheets, 'au moins une feuille de style').toBeGreaterThan(
+                0
+            );
+
+            await expect(page.locator('html')).toHaveClass(/dark/);
+
+            const { background, nav } = await page.evaluate(() => {
+                const auroraNav = document.querySelector('nav div');
+                return {
+                    background: getComputedStyle(document.body).backgroundColor,
+                    nav: auroraNav
+                        ? getComputedStyle(auroraNav).backgroundColor
+                        : '',
+                };
+            });
+            expect(
+                isDarkBackground(background),
+                `fond de page attendu sombre, obtenu ${background}`
+            ).toBe(true);
+            // Le bandeau de navigation est `bg-zinc-50 dark:bg-zinc-900` : c'est
+            // lui qui vire au blanc en premier quand la classe `dark` manque.
+            expect(
+                isDarkBackground(nav),
+                `bandeau de navigation attendu sombre, obtenu ${nav}`
+            ).toBe(true);
+        });
+
+        test(`${path} : un seul titre de niveau 1`, async ({ page }) => {
+            await page.goto(path);
+            await settle(page);
+            await expect(page.locator('h1')).toHaveCount(1);
+        });
+    }
+});
+
+test.describe('le thème sombre ne dépend de rien d’extérieur', () => {
+    /**
+     * Le défaut qui a fait passer le site en clair chez Yann : `next-themes`
+     * était en `enableSystem`, et une clé `theme` laissée dans `localStorage`
+     * par une visite précédente, ou par un autre projet servi sur le même
+     * `localhost:3000`, gagnait sur le thème par défaut. Le site n'ayant aucun
+     * sélecteur de thème, personne ne pouvait revenir en arrière.
+     */
+    for (const stored of ['system', 'light']) {
+        test(`localStorage.theme = "${stored}" ne bascule pas le site en clair`, async ({
+            page,
+        }) => {
+            await page.addInitScript(
+                (value) => window.localStorage.setItem('theme', value),
+                stored
+            );
+            await page.goto('/');
+            await settle(page);
+
+            await expect(page.locator('html')).toHaveClass(/dark/);
+
+            const nav = await page.evaluate(() => {
+                const el = document.querySelector('nav div');
+                return el ? getComputedStyle(el).backgroundColor : '';
+            });
+            expect(
+                isDarkBackground(nav),
+                `bandeau de navigation attendu sombre, obtenu ${nav}`
+            ).toBe(true);
+        });
+    }
+});
+
+test.describe('événements sans intervenant', () => {
+    /**
+     * `AvatarPersonality` affichait « N/A N/A » et « Unknown Title » sur les
+     * événements dont la personnalité n'est pas saisie dans le Studio. Le test
+     * balaie la liste et chaque fiche, plutôt que de viser un événement précis
+     * dont le contenu peut changer dans Sanity.
+     */
+    test('aucune valeur de substitution sur la liste et les fiches', async ({
+        page,
+    }) => {
+        test.setTimeout(180_000);
+        await page.goto('/events');
+        await settle(page);
+
+        const paths = await page.evaluate(() =>
+            Array.from(document.querySelectorAll('a[href^="/events/"]'))
+                .map((a) => a.getAttribute('href') ?? '')
+                .filter((href, index, all) => all.indexOf(href) === index)
+        );
+
+        for (const path of ['/events', ...paths]) {
+            // Le bloc intervenant est rendu par le serveur : inutile d'attendre
+            // les animations, le texte est là dès le HTML initial.
+            await page.goto(path, { waitUntil: 'domcontentloaded' });
+            const text = (await page.locator('body').innerText()) ?? '';
+            expect(text, `${path} ne doit pas afficher N/A`).not.toContain(
+                'N/A'
+            );
+            expect(
+                text,
+                `${path} ne doit pas afficher Unknown Title`
+            ).not.toContain('Unknown Title');
+        }
+    });
+});
+
+test.describe('annonce de rentrée', () => {
+    test("s'affiche sur l'accueil sans chevaucher le bouton flottant", async ({
+        page,
+    }) => {
+        await page.goto('/');
+        await settle(page);
+
+        const notice = page.getByRole('complementary', {
+            name: 'Annonce de rentrée',
+        });
+        await expect(notice).toBeVisible();
+
+        // Le surtitre est en `whitespace-nowrap` : s'il devient trop large, il
+        // déborde de la carte au lieu de passer à la ligne, et ça ne se voit pas
+        // depuis le code. Cinzel peut aussi tomber en police de repli.
+        const eyebrow = notice.locator('p').first();
+        const metrics = await eyebrow.evaluate((el) => {
+            // Largeur du texte, mesurée sur son contenu. La boîte du paragraphe
+            // occupe toute la largeur disponible et ne dit rien du débordement.
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            const style = getComputedStyle(el);
+            return {
+                overflows: el.scrollWidth > el.clientWidth + 1,
+                textWidth: range.getBoundingClientRect().width,
+                available: el.clientWidth,
+                fontSize: parseFloat(style.fontSize),
+                lines: Math.round(
+                    el.getBoundingClientRect().height /
+                        parseFloat(style.lineHeight)
+                ),
+            };
+        });
+
+        expect(metrics.lines, 'surtitre sur une seule ligne').toBe(1);
+        expect(
+            metrics.overflows,
+            `surtitre débordant : ${Math.round(metrics.textWidth)}px de texte pour ${metrics.available}px`
+        ).toBe(false);
+        // Marge suffisante pour absorber une police de repli si Cinzel tarde.
+        expect(
+            metrics.textWidth,
+            'surtitre trop proche du bord de la carte'
+        ).toBeLessThan(metrics.available * 0.9);
+
+        const floating = page.getByRole('link', { name: /Notre démo/i });
+        if (await floating.count()) {
+            const a = await notice.boundingBox();
+            const b = await floating.first().boundingBox();
+            if (a && b) {
+                const overlaps =
+                    a.x < b.x + b.width &&
+                    a.x + a.width > b.x &&
+                    a.y < b.y + b.height &&
+                    a.y + a.height > b.y;
+                expect(overlaps, 'annonce et bouton flottant disjoints').toBe(
+                    false
+                );
+            }
+        }
+    });
+});

--- a/emails/confirmation-email.tsx
+++ b/emails/confirmation-email.tsx
@@ -10,15 +10,18 @@ import {
     Tailwind,
     Text,
 } from '@react-email/components';
+import { associationConfig } from '@/constant/config';
 
 type ConfirmationEmailProps = {
     firstName: string;
     lastName: string;
 };
 
-const PRESIDENT_NAME = 'Fanny GABORIT';
-const PRESIDENT_EMAIL = 'president@jeetkunedo31.com';
-const PRESIDENT_PHONE = '+33 6 84 05 93 26';
+// Source unique : ces coordonnées sont aussi celles du site, du JSON-LD et des
+// supports imprimés. Les dupliquer ici avait fait diverger l'adresse de contact.
+const PRESIDENT_NAME = associationConfig.legal.director;
+const PRESIDENT_EMAIL = associationConfig.email;
+const PRESIDENT_PHONE = associationConfig.phoneNumber;
 
 export function ConfirmationEmail({
     firstName,

--- a/lib/announcement.test.ts
+++ b/lib/announcement.test.ts
@@ -1,0 +1,70 @@
+import type { Announcement } from '@/constant/announcement';
+import { describe, expect, it } from 'vitest';
+import { isAnnouncementVisible, selectVisibleAnnouncement } from './announcement';
+
+const base: Announcement = {
+    eyebrow: 'Rentrée 2026 · 2027',
+    message: 'Reprise des cours le mardi 8 septembre.',
+    visibleFrom: '2026-08-25',
+    visibleUntil: '2026-10-04',
+};
+
+const at = (iso: string) => new Date(iso);
+
+describe('isAnnouncementVisible', () => {
+    it("masque l'annonce avant le premier jour", () => {
+        expect(isAnnouncementVisible(base, at('2026-08-24T23:59:59Z'))).toBe(
+            false
+        );
+    });
+
+    it("affiche l'annonce dès le premier jour", () => {
+        expect(isAnnouncementVisible(base, at('2026-08-25T00:00:00Z'))).toBe(
+            true
+        );
+    });
+
+    it('affiche encore le dernier jour, en fin de journée', () => {
+        expect(isAnnouncementVisible(base, at('2026-10-04T23:00:00Z'))).toBe(
+            true
+        );
+    });
+
+    it('masque le lendemain du dernier jour', () => {
+        expect(isAnnouncementVisible(base, at('2026-10-05T00:00:00Z'))).toBe(
+            false
+        );
+    });
+
+    it('masque une annonce dont les dates sont inversées', () => {
+        const inverted = {
+            ...base,
+            visibleFrom: '2026-10-04',
+            visibleUntil: '2026-08-25',
+        };
+        expect(isAnnouncementVisible(inverted, at('2026-09-01T12:00:00Z'))).toBe(
+            false
+        );
+    });
+
+    it('masque une annonce dont une date est illisible', () => {
+        const broken = { ...base, visibleUntil: 'octobre' };
+        expect(isAnnouncementVisible(broken, at('2026-09-01T12:00:00Z'))).toBe(
+            false
+        );
+    });
+});
+
+describe('selectVisibleAnnouncement', () => {
+    it("rend l'annonce pendant la fenêtre", () => {
+        expect(selectVisibleAnnouncement(base, at('2026-09-01T12:00:00Z'))).toBe(
+            base
+        );
+    });
+
+    it('rend null en dehors', () => {
+        expect(
+            selectVisibleAnnouncement(base, at('2026-12-01T12:00:00Z'))
+        ).toBeNull();
+    });
+});

--- a/lib/announcement.ts
+++ b/lib/announcement.ts
@@ -1,0 +1,36 @@
+import type { Announcement } from '@/constant/announcement';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const dayStart = (isoDay: string): number | null => {
+    const time = new Date(`${isoDay}T00:00:00Z`).getTime();
+    return Number.isNaN(time) ? null : time;
+};
+
+/**
+ * Une annonce est visible entre le premier jour et le dernier jour, ce dernier
+ * inclus. `visibleUntil: '2026-10-04'` affiche donc l'annonce pendant toute la
+ * journée du 4 octobre, et elle disparaît le 5 au matin.
+ *
+ * Une date illisible masque l'annonce plutôt que de l'afficher indéfiniment :
+ * une coquille de saisie ne doit pas laisser une information périmée en ligne.
+ */
+export const isAnnouncementVisible = (
+    announcement: Announcement,
+    now: Date = new Date()
+): boolean => {
+    const from = dayStart(announcement.visibleFrom);
+    const until = dayStart(announcement.visibleUntil);
+    if (from === null || until === null) return false;
+    if (until < from) return false;
+
+    const time = now.getTime();
+    return time >= from && time < until + DAY_IN_MS;
+};
+
+/** L'annonce si elle doit être affichée, sinon `null`. */
+export const selectVisibleAnnouncement = (
+    announcement: Announcement,
+    now: Date = new Date()
+): Announcement | null =>
+    isAnnouncementVisible(announcement, now) ? announcement : null;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "build": "next build",
         "start": "next start",
         "lint": "eslint .",
-        "test": "vitest run"
+        "test": "vitest run",
+        "test:e2e": "playwright test"
     },
     "dependencies": {
         "@lordicon/element": "^1.6.0",
@@ -51,6 +52,7 @@
     },
     "devDependencies": {
         "@next/bundle-analyzer": "^16.1.3",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/typography": "^0.5.13",
         "@types/node": "^20",
         "@types/react": "^19.2.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Vérifications de rendu réel, dans un vrai navigateur.
+ *
+ * `BASE_URL` permet de viser le serveur de développement déjà lancé
+ * (`http://localhost:3000`) plutôt que d'en démarrer un second : `next dev` et
+ * `next build` partagent le dossier `.next`, les lancer en parallèle corrompt
+ * les fichiers CSS servis en développement.
+ */
+const baseURL = process.env.BASE_URL ?? 'http://localhost:3000';
+
+export default defineConfig({
+    testDir: './e2e',
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    fullyParallel: false,
+    workers: 1,
+    reporter: [['list']],
+    use: {
+        baseURL,
+        // Utilise le Chrome installé sur la machine, pas un binaire téléchargé.
+        channel: 'chrome',
+        // Volontairement clair : le site doit rester sombre quelle que soit la
+        // préférence du système. Forcer `dark` ici rendait le test infalsifiable.
+        colorScheme: 'light',
+    },
+    projects: [
+        {
+            name: 'desktop',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        },
+        {
+            name: 'mobile',
+            use: {
+                ...devices['Pixel 7'],
+                channel: 'chrome',
+                isMobile: false,
+                hasTouch: true,
+                defaultBrowserType: 'chromium',
+            },
+        },
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,10 @@ importers:
         version: 7.0.5
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.3.1(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.3.1(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -70,10 +70,10 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: ^16.1.3
-        version: 16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-sanity:
         specifier: ^12.0.12
-        version: 12.0.12(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@5.4.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@portabletext/sanity-bridge@2.0.0(@types/react@19.2.8))(@types/node@20.19.30)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+        version: 12.0.12(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@5.4.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@portabletext/sanity-bridge@2.0.0(@types/react@19.2.8))(@types/node@20.19.30)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -117,6 +117,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^16.1.3
         version: 16.1.3
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/typography':
         specifier: ^0.5.13
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -2070,6 +2073,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -4945,6 +4953,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6196,6 +6209,16 @@ packages:
 
   player.style@0.3.1:
     resolution: {integrity: sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pluralize-esm@9.0.5:
     resolution: {integrity: sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==}
@@ -9910,6 +9933,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -11270,7 +11297,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 5.4.0(@types/react@19.2.8)(debug@4.4.3)
 
-  '@sanity/visual-editing@5.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+  '@sanity/visual-editing@5.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.3)
@@ -11289,7 +11316,7 @@ snapshots:
       xstate: 5.25.1
     optionalDependencies:
       '@sanity/client': 7.14.0(debug@4.4.3)
-      next: 16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -11924,16 +11951,16 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/edge@1.2.2': {}
 
-  '@vercel/speed-insights@1.3.1(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@1.3.1(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@vercel/stega@1.0.0': {}
@@ -13366,6 +13393,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14274,18 +14304,18 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-sanity@12.0.12(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@5.4.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@portabletext/sanity-bridge@2.0.0(@types/react@19.2.8))(@types/node@20.19.30)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3):
+  next-sanity@12.0.12(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@5.4.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@portabletext/sanity-bridge@2.0.0(@types/react@19.2.8))(@types/node@20.19.30)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.0.2(react@19.2.3)
       '@sanity/client': 7.14.0(debug@4.4.3)
       '@sanity/comlink': 4.0.1
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.0(debug@4.4.3))(@sanity/types@5.4.0(@types/react@19.2.8)(debug@4.4.3))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.0(debug@4.4.3))
-      '@sanity/visual-editing': 5.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@sanity/visual-editing': 5.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.0)(@sanity/types@5.4.0(@types/react@19.2.8))(next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       dequal: 2.0.3
       groq: 5.4.0
       history: 5.3.0
-      next: 16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       sanity: 5.4.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@portabletext/sanity-bridge@2.0.0(@types/react@19.2.8))(@types/node@20.19.30)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(babel-plugin-react-compiler@1.0.0)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -14306,7 +14336,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.3(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.28.6)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -14325,6 +14355,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.3
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -14644,6 +14675,14 @@ snapshots:
       media-chrome: 4.16.1(react@19.2.3)
     transitivePeerDependencies:
       - react
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize-esm@9.0.5: {}
 

--- a/sanity/lib/imageUrl.ts
+++ b/sanity/lib/imageUrl.ts
@@ -1,5 +1,4 @@
-// ./sanity/lib/imageUrl.js
-import { createImageUrlBuilder } from '@sanity/image-url';
+import { createImageUrlBuilder, type SanityImageSource } from '@sanity/image-url';
 import { dataset, projectId } from '../env';
 
 const builder = createImageUrlBuilder({
@@ -7,6 +6,15 @@ const builder = createImageUrlBuilder({
     dataset: dataset || '',
 });
 
-export function urlFor(source: string) {
+/**
+ * Construit une URL d'image Sanity.
+ *
+ * Passer l'objet image complet (`event.mainImage`) et non `asset._ref` : le
+ * point de recadrage (`hotspot`) et le cadrage (`crop`) saisis dans le Studio
+ * vivent sur cet objet. Avec la seule référence d'asset, ils sont perdus et
+ * toute demande de format fixe recadre au centre, ce qui décapite les affiches
+ * verticales sur les aperçus Open Graph en 1200 × 630.
+ */
+export function urlFor(source: SanityImageSource) {
     return builder.image(source);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,19 @@ const config = {
         extend: {
             colors: {
                 jkdBlue: '#006599',
+                /**
+                 * Variante éclaircie de `jkdBlue`, pour le petit texte sur fond
+                 * sombre. `#006599` sur noir tombe à 2,4:1, sous le minimum de
+                 * 4,5:1 exigé par le WCAG pour du texte de moins de 18 px.
+                 */
+                jkdBlueLight: '#4DA6D9',
+                /** Rouge du logo, déjà utilisé par le badge des événements internes. */
+                jkdRed: '#E20614',
+                /**
+                 * Variante éclaircie de `jkdRed` pour le petit texte sur fond
+                 * sombre : `#E20614` plafonne à 3,4:1, sous le minimum de 4,5:1.
+                 */
+                jkdRedLight: '#FF4D57',
                 border: 'hsl(var(--border))',
                 input: 'hsl(var(--input))',
                 ring: 'hsl(var(--ring))',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
         alias: { '@': fileURLToPath(new URL('.', import.meta.url)) },
     },
     test: {
-        include: ['lib/**/*.test.ts'],
+        // Les tests de composants rendent du HTML serveur (`renderToStaticMarkup`),
+        // ce qui teste exactement ce que voient les robots. Pas besoin de jsdom.
+        include: ['lib/**/*.test.ts', 'components/**/*.test.tsx'],
         environment: 'node',
     },
 });


### PR DESCRIPTION
Relevé en production le 30 août 2026, corrigé, et vérifié dans un vrai navigateur.

## Ce que ça corrige

**Un seul `h1` par page.** `GradualSpacing` enveloppait chaque caractère animé dans son propre `motion.h1`. Mesuré sur le HTML servi par la production :

| Page | avant | après |
|---|---:|---:|
| `/` | 0, puis 39 après hydratation | 1 |
| `/tarifs` | 47 | 1 |
| `/27-styles` | 60 | 1 |
| `/contact` | 14 | 1 |
| `/events` | 10 | 1 |

Les 39 venaient du menu, présent sur toutes les pages. Un lecteur d'écran épelait le titre lettre par lettre.

**Titres et descriptions.** Aucun ne contenait « Muret », et `/tarifs` portait mot pour mot la description de `/association`. Un `title.template` au niveau racine suffixe automatiquement les fiches événement, qui n'affichaient pas le nom du club.

**Thème sombre imposé.** `next-themes` était en `enableSystem` sans sélecteur de thème rendu. Une clé `theme` laissée dans `localStorage`, éventuellement par un autre projet servi sur le même `localhost:3000`, basculait tout le site en clair sans retour possible.

**« N/A N/A » sur les événements.** `AvatarPersonality` avait des valeurs de substitution par défaut, affichées telles quelles quand aucune personnalité n'est saisie dans le Studio.

**Hotspot Sanity.** `urlFor` recevait la seule référence de l'asset, donc le point de recadrage était jeté et l'image Open Graph des événements recadrait au centre.

**Adresse de contact** unifiée sur `contact@jkd-selfdefense31.fr`.

## Ce que ça ajoute

Une annonce de rentrée dans le bas du héros de l'accueil et en haut de `/tarifs`, avec une fenêtre d'affichage qui la fait disparaître d'elle-même. Contenu codé en dur, à la forme du futur document Sanity `annonce`.

## Vérification

`pnpm lint` 0 erreur, `tsc --noEmit` propre, **42 tests unitaires**, **38 tests Playwright** contre un build de production.

Les tests Playwright tournent avec `colorScheme: 'light'` et un `localStorage` pollué, précisément les conditions qui reproduisaient la panne. Leur falsifiabilité a été vérifiée en réintroduisant temporairement chaque défaut et en constatant l'échec.

Non-régression visuelle mesurée contre la production, à viewport identique : hauteurs de page strictement égales sur `/` (3722 px), `/tarifs` (4115 px), `/27-styles` (3411 px) et `/contact` (2342 px), et repères de mise en page identiques au pixel.

## Reste à faire, hors périmètre

- créer la boîte `contact@jkd-selfdefense31.fr`, le site l'affiche déjà
- sortir les cinq événements externes du sitemap, leur canonical pointe ailleurs
- champ `organisateur` optionnel dans le schéma événement
- passer l'annonce dans Sanity quand la version codée en dur aura fait ses preuves

Détail et arbitrages : `docs/reviews/2026-08-30-titres-metadonnees-annonce.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
